### PR TITLE
refactor: :recycle: Keep main nemo check example plugin for config

### DIFF
--- a/resources/config/config.yaml
+++ b/resources/config/config.yaml
@@ -1,41 +1,5 @@
 # plugins/config.yaml - Main plugin configuration file
 plugins:
-  # Self-contained Search Replace Plugin - depends on plugin availability
-  - name: "ReplaceBadWordsPlugin"
-    # From https://github.com/contextforge-org/contextforge-plugins-python
-    kind: "contextforge-plugins-python.regex_filter.search_replace.SearchReplacePlugin"
-    description: "A plugin for finding and replacing words."
-    version: "0.1.0"
-    author: "Teryl Taylor"
-    hooks: ["prompt_pre_fetch", "prompt_post_fetch", "tool_pre_invoke", "tool_post_invoke"]
-    tags: ["plugin", "transformer", "regex", "search-and-replace", "pre-post"]
-    mode: "enforce"  # enforce | permissive | disabled
-    priority: 150
-    conditions:
-      # Apply to specific tools/servers
-      - prompts: ["test_prompt"]
-        server_ids: []  # Apply to all servers
-        tenant_ids: []  # Apply to all tenants
-    config:
-      words:
-        - search: crap
-          replace: crud
-        - search: crud
-          replace: yikes
-
-  # Nemo example
-  - name: "NemoWrapperPlugin"
-    kind: "plugins.examples.nemo.nemo_wrapper_plugin.NemoWrapperPlugin"
-    description: "A simple Nemo PII detector"
-    version: "0.1.0"
-    author: "Evaline Ju"
-    hooks: ["tool_pre_invoke", "tool_post_invoke"]
-    tags: ["plugin", "pre-post"]
-    mode: "enforce"  # enforce | permissive | disabled
-    priority: 150
-    config:
-      foo: bar
-
   # Nemo Check Example
   - name: "NemoCheck"
     kind: "plugins.examples.nemocheck.plugin.NemoCheck"
@@ -51,8 +15,7 @@ plugin_dirs:
   - "plugins/native"                # Built-in plugins
   - "plugins/custom"                # Custom organization plugins
   - "/etc/mcpgateway/plugins"       # System-wide plugins
-  - "plugins/examples/nemo"         # Example Nemo guardrails plugins
-  - "plugins/examples/nemocheck"    # Nemo Check Server plugins
+  - "plugins/examples/nemocheck"    # NeMo Check Server plugins
 
 # Global plugin settings
 plugin_settings:

--- a/resources/config/default_config.yaml
+++ b/resources/config/default_config.yaml
@@ -2,6 +2,7 @@
 plugins:
 # Self-contained Search Replace Plugin
   - name: "ReplaceBadWordsPlugin"
+    # Provide or copy from https://github.com/contextforge-org/contextforge-plugins-python
     kind: "plugins.regex_filter.search_replace.SearchReplacePlugin"
     description: "A plugin for finding and replacing words."
     version: "0.1.0"
@@ -22,11 +23,36 @@ plugins:
         - search: crud
           replace: yikes
 
+  # Nemo example
+  - name: "NemoWrapperPlugin"
+    kind: "plugins.examples.nemo.nemo_wrapper_plugin.NemoWrapperPlugin"
+    description: "A simple Nemo PII detector"
+    version: "0.1.0"
+    author: "Evaline Ju"
+    hooks: ["tool_pre_invoke", "tool_post_invoke"]
+    tags: ["plugin", "pre-post"]
+    mode: "enforce"  # enforce | permissive | disabled
+    priority: 150
+    config:
+      foo: bar
+
+  # Nemo Check Example
+  - name: "NemoCheck"
+    kind: "plugins.examples.nemocheck.plugin.NemoCheck"
+    description: "Adapter for nemo check server"
+    hooks: ["tool_pre_invoke", "tool_post_invoke"]
+    version: "0.1.0"
+    author: "Julian Stephen"
+    config:
+      nemo_guardrails_url: "http://nemo-guardrails-service:8000"
+
 # Plugin directories to scan
 plugin_dirs:
-  - "plugins/native"      # Built-in plugins
-  - "plugins/custom"      # Custom organization plugins
-  - "/etc/mcpgateway/plugins"  # System-wide plugins
+  - "plugins/native"                # Built-in plugins
+  - "plugins/custom"                # Custom organization plugins
+  - "/etc/mcpgateway/plugins"       # System-wide plugins
+  - "plugins/examples/nemo"         # Example NeMo guardrails plugins
+  - "plugins/examples/nemocheck"    # Example NeMo Check Server plugins
 
 # Global plugin settings
 plugin_settings:


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

We are focusing on testing with the (internal) nemo check plugin, and have not vendored the ReplaceBadWordsPlugin (has to be either copied or referred to). The current Dockerfile and deploy scripts use the config/config.yaml by default, so we focus on only the nemo check plugin. The others could have been commented out, but I've removed them and put them in `default_config.yaml` to avoid confusion. They can still be referred to from that config.
