### PR TITLE
Feat: Add issue self-assign caller workflow

### DIFF
--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -1,0 +1,22 @@
+# Issue Self-Assign
+#
+# Thin caller for the org-wide reusable self-assign workflow.
+# Configuration and defaults are managed centrally in kagenti/.github.
+#
+# Reference: https://github.com/kagenti/.github/blob/main/.github/workflows/self-assign-reusable.yml
+#
+name: Issue self-assign
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  self-assign:
+    uses: kagenti/.github/.github/workflows/self-assign-reusable.yml@main
+    secrets:
+      ISSUE_ASSIGN_TOKEN: ${{ secrets.ISSUE_ASSIGN_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to this project
+
+Greetings! We are grateful for your interest in joining the Kagenti community and making a positive impact. Whether you're raising issues, enhancing documentation, fixing bugs, or developing new features, your contributions are essential to our success.
+
+To get started, kindly read through this document and familiarize yourself with our code of conduct.
+
+We can't wait to collaborate with you!
+
+## Contributing Code
+
+Please follow the [Contribution guide](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md#contributing-to-this-project) as found in the Kagenti Repository for instructions on how to contribute to our repositories.
+
+## Claiming an Issue
+
+Comment `/claim` on an issue to have it automatically assigned to you. Issues labeled `blocked` or `in-progress` cannot be claimed this way. If you need to release an issue, comment `/unassign` or ask a maintainer.


### PR DESCRIPTION
## Summary
- Adds caller workflow for org-wide issue self-assign (`/claim`)
- Adds CONTRIBUTING.md with contribution guide and `/claim` instructions

## Test plan
- [ ] Depends on kagenti/.github reusable workflow being merged first
- [ ] Comment `/claim` on an issue from a non-member account
- [ ] Verify assignment and bot reply