### PR TITLE
feat: bootstrap orchestrate skills for self-sufficient orchestration

### DIFF
--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: orchestrate
+description: Enhance any repository with CI, tests, skills, and security through phased PRs - self-replicating
+---
+
+```mermaid
+flowchart TD
+    START(["/orchestrate"]) --> HAS_SCAN{Has scan report?}
+
+    HAS_SCAN -->|No| SCAN["orchestrate:scan"]:::orch
+    SCAN --> PLAN["orchestrate:plan"]:::orch
+    HAS_SCAN -->|Yes| HAS_PLAN{Has plan?}
+
+    HAS_PLAN -->|No| PLAN
+    HAS_PLAN -->|Yes| NEXT_PHASE{Next phase?}
+
+    NEXT_PHASE -->|Phase 2| PRECOMMIT["orchestrate:precommit<br/>PR #1"]:::orch
+    NEXT_PHASE -->|Phase 3| TESTS["orchestrate:tests<br/>PR #2"]:::orch
+    NEXT_PHASE -->|Phase 4| CI["orchestrate:ci<br/>PR #3"]:::orch
+    NEXT_PHASE -->|Phase 5| SECURITY["orchestrate:security<br/>PR #4"]:::orch
+    NEXT_PHASE -->|Phase 6| REPLICATE["orchestrate:replicate<br/>PR #5"]:::orch
+    NEXT_PHASE -->|Phase 7| REVIEW["orchestrate:review"]:::orch
+
+    PRECOMMIT --> TESTS
+    TESTS --> CI
+    CI --> SECURITY
+    SECURITY --> REPLICATE
+    REPLICATE --> REVIEW
+    REVIEW -->|optional| ONBOARD_LINK["onboard:link"]:::onb
+    ONBOARD_LINK --> ONBOARD_STD["onboard:standards"]:::onb
+    REVIEW --> DONE([All phases complete])
+
+    classDef orch fill:#FF9800,stroke:#333,color:white
+    classDef onb fill:#9C27B0,stroke:#333,color:white
+    classDef check fill:#FFC107,stroke:#333,color:black
+    class HAS_SCAN,HAS_PLAN,NEXT_PHASE check
+```
+
+> Follow this diagram as the workflow.
+
+# Orchestrate Skills
+
+Enhance any repository with CI, tests, skills, and security through a series of phased PRs. Each phase produces a focused, reviewable PR of 600-700 lines.
+
+## Entry Point Routing
+
+When `/orchestrate` is invoked, determine the action:
+
+```
+What was provided?
+    |
+    +-- /orchestrate <repo-path>
+    |     New target. Clone or locate the repo, then start from scan.
+    |     Example: /orchestrate .repos/my-service
+    |
+    +-- /orchestrate <phase>
+    |     Jump to a specific phase. Requires scan + plan to already exist.
+    |     Example: /orchestrate ci
+    |
+    +-- /orchestrate status
+          Show current orchestration state for all tracked targets.
+```
+
+### Route logic
+
+1. **`/orchestrate <repo-path>`** -- If the path points to a git repository, derive the target name from the directory basename. Check `/tmp/kagenti/orchestrate/<target>/` for existing state. If no scan report exists, invoke `orchestrate:scan`. If scan exists but no plan, invoke `orchestrate:plan`. If both exist, determine the next incomplete phase and invoke it.
+
+2. **`/orchestrate <phase>`** -- Validate that `scan-report.md` and `plan.md` exist for the current target. If missing, instruct the user to run `/orchestrate <repo-path>` first. Otherwise invoke the requested phase skill directly (e.g., `orchestrate:precommit`).
+
+3. **`/orchestrate status`** -- List all directories under `/tmp/kagenti/orchestrate/`, read each target's `phase-status.md`, and display a summary table showing target name, current phase, and completion percentage.
+
+## Phase Status Tracking
+
+All orchestration state is persisted under `/tmp/kagenti/orchestrate/<target>/`:
+
+| File | Purpose |
+|------|---------|
+| `scan-report.md` | Output of `orchestrate:scan` -- repo structure, tech stack, gaps |
+| `plan.md` | Output of `orchestrate:plan` -- enhancement plan with phases and PR scope |
+| `phase-status.md` | Tracks which phases are complete, in-progress, or pending |
+
+The `phase-status.md` file uses this format:
+
+```markdown
+# Orchestration Status: <target>
+
+| Phase | Status | PR | Updated |
+|-------|--------|----|---------|
+| scan | complete | -- | 2025-01-15 |
+| plan | complete | -- | 2025-01-15 |
+| precommit | complete | #42 | 2025-01-16 |
+| tests | in-progress | #43 | 2025-01-17 |
+| ci | pending | -- | -- |
+| security | pending | -- | -- |
+| replicate | pending | -- | -- |
+| review | pending | -- | -- |
+```
+
+Each phase skill is responsible for updating `phase-status.md` when it starts and completes.
+
+## Phase Overview
+
+| Phase | Skill | PR | Description |
+|-------|-------|-----|-------------|
+| 0 | orchestrate:scan | -- | Assess target repo structure, tech stack, and gaps |
+| 1 | orchestrate:plan | -- | Brainstorm enhancements and produce a phased plan |
+| 2 | orchestrate:precommit | PR #1 | Pre-commit hooks, linting, and code formatting |
+| 3 | orchestrate:tests | PR #2 | Test infrastructure and initial test coverage |
+| 4 | orchestrate:ci | PR #3 | Comprehensive CI: lint, test, build, security scanning, dependabot, scorecard |
+| 5 | orchestrate:security | PR #4 | Security governance: CODEOWNERS, SECURITY.md, CONTRIBUTING.md, LICENSE |
+| 6 | orchestrate:replicate | PR #5 | Bootstrap Claude Code skills into the target repo |
+| 7 | orchestrate:review | -- | Review all orchestration PRs before merge |
+
+Phases are sequential. Each PR builds on the previous one. Tests come before CI (so CI can run them) and before security (so code refactoring for security fixes has test coverage as a safety net). The scan and plan phases do not produce PRs -- they produce artifacts that guide all subsequent phases.
+
+## Self-Replication
+
+Phase 6 (`orchestrate:replicate`) is what makes this system fractal. It copies a starter set of Claude Code skills into the target repository, including a tailored version of the orchestrate skill itself. Once replicated, the target repo can orchestrate other repos using the same phased approach.
+
+This means every repository that goes through orchestration gains the ability to orchestrate others. The skills adapt to the target's tech stack (the scan report informs what language-specific linters, test frameworks, and CI patterns to use).
+
+## Quick Start
+
+```bash
+# Clone target repo into a working directory
+git clone git@github.com:org/repo.git .repos/repo-name
+
+# Run the full orchestration pipeline
+# /orchestrate .repos/repo-name
+
+# Or jump to a specific phase (if scan + plan already exist)
+# /orchestrate precommit
+
+# Check status across all targets
+# /orchestrate status
+```
+
+## Related Skills
+
+### Orchestrate sub-skills
+
+| Skill | Description |
+|-------|-------------|
+| `orchestrate:scan` | Assess target repo structure and identify gaps |
+| `orchestrate:plan` | Produce a phased enhancement plan |
+| `orchestrate:precommit` | Add pre-commit hooks, linters, formatters |
+| `orchestrate:ci` | Comprehensive CI: lint, test, build, security scanning, dependabot, scorecard |
+| `orchestrate:tests` | Add test infrastructure and initial test coverage |
+| `orchestrate:security` | Security governance: CODEOWNERS, SECURITY.md, CONTRIBUTING.md, LICENSE |
+| `orchestrate:replicate` | Bootstrap Claude Code skills into the target |
+| `orchestrate:review` | Review all orchestration PRs before merge |
+
+### Onboard skills
+
+| Skill | Description |
+|-------|-------------|
+| `onboard:link` | Link a newly-orchestrated repo to Kagenti |
+| `onboard:standards` | Apply organizational standards and conventions |

--- a/.claude/skills/orchestrate:ci/SKILL.md
+++ b/.claude/skills/orchestrate:ci/SKILL.md
@@ -1,0 +1,411 @@
+---
+name: orchestrate:ci
+description: Add comprehensive CI workflows to a target repo - lint, test, build, security scanning, dependabot, scorecard, action pinning
+---
+
+```mermaid
+flowchart TD
+    START(["/orchestrate:ci"]) --> READ["Read plan + scan report"]:::orch
+    READ --> DETECT["Detect tech stack + CI gaps"]:::orch
+    DETECT --> T1["Tier 1: Universal checks"]:::orch
+    T1 --> T2{"Tier 2 needed?"}
+    T2 -->|Yes| T2_GEN["Tier 2: Conditional checks"]:::orch
+    T2 -->|No| T3
+    T2_GEN --> T3{"Tier 3 needed?"}
+    T3 -->|Yes| T3_GEN["Tier 3: Advanced patterns"]:::orch
+    T3 -->|No| BRANCH
+    T3_GEN --> BRANCH["Create branch"]:::orch
+    BRANCH --> SIZE{Under 700 lines?}
+    SIZE -->|Yes| PR["Commit + open PR"]:::orch
+    SIZE -->|No| SPLIT["Split into sub-PRs"]:::orch
+    SPLIT --> PR
+    PR --> DONE([Phase complete])
+
+    classDef orch fill:#FF9800,stroke:#333,color:white
+```
+
+> Follow this diagram as the workflow.
+
+# Orchestrate: CI
+
+Add comprehensive CI workflows to a target repository. This is Phase 4 and
+produces PR #3. Implements the gold standard for CI: lint, test, build,
+security scanning, dependency management, and supply chain hardening.
+
+## When to Use
+
+- After `orchestrate:plan` identifies CI as a needed phase
+- After precommit and tests phases (so CI can run the test suite)
+
+## Prerequisites
+
+- Plan exists at `/tmp/kagenti/orchestrate/<target>/plan.md`
+- Scan report at `/tmp/kagenti/orchestrate/<target>/scan-report.md`
+- Target repo in `.repos/<target>/`
+
+## Read Scan Report First
+
+Before generating anything, read the scan report to determine:
+- Tech stack (Python, Go, Node, Ansible, Rust, multi-language)
+- Existing CI workflows (what to preserve vs replace)
+- Dockerfiles present (triggers container build workflows)
+- Existing dependabot config (what ecosystems are covered)
+- Existing security scanning (what's already in place)
+
+---
+
+## Tier 1: Universal Checks (Always Generate)
+
+Every repo gets these regardless of tech stack.
+
+### 1.1 Core CI Workflow (`ci.yml`)
+
+**Trigger:** `pull_request` on `main` and `push` to `main`
+
+Adapt to tech stack from scan report:
+
+| Language | Lint | Test | Build |
+|----------|------|------|-------|
+| Python | `ruff check .` + `ruff format --check .` | `pytest -v` | `uv build` (if pyproject.toml has build-system) |
+| Go | `golangci-lint run` | `go test ./... -v -race` | `go build ./...` |
+| Node | `npm run lint` | `npm test` | `npm run build` |
+| Rust | `cargo clippy -- -D warnings` | `cargo test` | `cargo build --release` |
+| Ansible | `ansible-lint` | `molecule test` (if molecule config exists) | — |
+
+For multi-language repos, create separate jobs per language.
+
+All CI workflows MUST include:
+- `permissions: contents: read` (explicit least-privilege)
+- `timeout-minutes: 15` (prevent hung jobs)
+- Language-appropriate dependency caching
+- Pre-commit run (if `.pre-commit-config.yaml` exists): `pre-commit run --all-files`
+
+For simpler single-language repos, combine lint + test + build into one `ci.yml`.
+For larger repos, split into `lint.yml`, `test.yml`, `build.yml`.
+
+### 1.2 Security Scans Workflow (`security-scans.yml`)
+
+**Trigger:** `pull_request` on `main`
+
+Generate parallel jobs based on what's in the repo. Always include dependency
+review. Add language-specific SAST and file-type linters only when relevant files
+exist.
+
+**Required permissions pattern:**
+
+```yaml
+permissions: {}  # Top-level: deny all
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@<SHA>  # Always SHA-pinned
+      - uses: actions/dependency-review-action@<SHA>
+        with:
+          fail-on-severity: moderate
+          deny-licenses: GPL-3.0, AGPL-3.0
+```
+
+**Conditional jobs (include only when relevant files exist):**
+
+| Job | When to Include | Tool |
+|-----|----------------|------|
+| Dependency review | Always | `actions/dependency-review-action` |
+| Trivy filesystem | Always | `aquasecurity/trivy-action` (fs scan, CRITICAL+HIGH) |
+| CodeQL | Python or Go or JS/TS | `github/codeql-action` with `security-extended` |
+| Bandit | Python files exist | `PyCQA/bandit` (HIGH severity blocks) |
+| gosec | Go files exist | `securego/gosec` |
+| Hadolint | Dockerfiles exist | `hadolint/hadolint-action` |
+| Shellcheck | `.sh` files exist | `ludeeus/action-shellcheck` |
+| YAML lint | `.yml`/`.yaml` in workflows/charts | `ibiqlik/action-yamllint` |
+| Helm lint | `Chart.yaml` exists | `helm lint` |
+| Action pinning | `.github/workflows/` exists | Custom step or `zgosalvez/github-actions-ensure-sha-pinned-actions` |
+
+**Trivy reference config:**
+
+```yaml
+  trivy-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@<SHA>
+      - uses: aquasecurity/trivy-action@<SHA>
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: CRITICAL,HIGH
+          exit-code: 1
+          format: sarif
+          output: trivy-results.sarif
+      - uses: github/codeql-action/upload-sarif@<SHA>
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+```
+
+**CodeQL reference config:**
+
+```yaml
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@<SHA>
+      - uses: github/codeql-action/init@<SHA>
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+      - uses: github/codeql-action/analyze@<SHA>
+```
+
+### 1.3 Dependabot Configuration (`dependabot.yml`)
+
+Generate `.github/dependabot.yml` covering ALL detected ecosystems:
+
+```yaml
+version: 2
+updates:
+  # Always include GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+```
+
+**Add per detected ecosystem:**
+
+| Marker File | Ecosystem | Directory |
+|-------------|-----------|-----------|
+| `pyproject.toml` or `requirements.txt` | `pip` | `/` (or subdir) |
+| `go.mod` | `gomod` | `/` (or subdir) |
+| `package.json` | `npm` | `/` (or subdir) |
+| `Cargo.toml` | `cargo` | `/` (or subdir) |
+| `Dockerfile` | `docker` | `/` (or subdir with Dockerfiles) |
+
+For monorepo structures with multiple `go.mod` or `pyproject.toml` files,
+add separate entries for each directory.
+
+### 1.4 OpenSSF Scorecard Workflow (`scorecard.yml`)
+
+```yaml
+name: Scorecard
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "30 6 * * 1"  # Weekly Monday 6:30 AM UTC
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@<SHA>
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@<SHA>
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: actions/upload-artifact@<SHA>
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 30
+      - uses: github/codeql-action/upload-sarif@<SHA>
+        with:
+          sarif_file: results.sarif
+```
+
+### 1.5 Action Pinning Check
+
+Add as a job in `security-scans.yml` or standalone:
+
+```yaml
+  action-pinning:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@<SHA>
+      - name: Check action pinning
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@<SHA>
+        with:
+          allowlist: |
+            actions/
+```
+
+Start as informational (`continue-on-error: true`). Recommend tightening
+after all actions are SHA-pinned.
+
+---
+
+## Tier 2: Conditional Checks (Based on Scan Report)
+
+### 2.1 Container Build Workflow (`build.yml`)
+
+**Include when:** Dockerfiles detected in scan report.
+
+**Trigger:** Tag push (`v*`) and `workflow_dispatch`
+
+Generate multi-arch build matrix:
+
+```yaml
+strategy:
+  matrix:
+    image:
+      - name: <image-name>
+        context: <path-to-dockerfile-dir>
+        file: <Dockerfile-path>
+```
+
+Use `docker/build-push-action` with:
+- QEMU for multi-arch (amd64 + arm64)
+- Buildx
+- GHCR push (`ghcr.io/${{ github.repository }}/<image>`)
+- OCI labels via `docker/metadata-action`
+
+### 2.2 Stale Issues Workflow (`stale.yml`)
+
+**Include when:** Repo is actively maintained (has recent commits).
+
+Use the kagenti org reusable workflow:
+
+```yaml
+name: Close Stale Issues and PRs
+on:
+  schedule:
+    - cron: "30 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    uses: kagenti/.github/.github/workflows/stale.yaml@main
+```
+
+### 2.3 PR Title Verification
+
+**Include when:** Repo follows conventional commit format.
+
+Use the org reusable workflow or `amannn/action-semantic-pull-request`.
+
+---
+
+## Tier 3: Advanced Patterns (User Confirms)
+
+Flag these in the PR description as optional. Only generate if the scan report
+indicates they are needed AND the user confirms.
+
+### 3.1 Comment-Triggered E2E (`e2e-pr.yml`)
+
+For repos with expensive E2E tests that require secrets:
+
+- Use `issue_comment` trigger (not `pull_request_target`)
+- Authorization job: check commenter has write permission
+- Add `safe-to-test` label flow
+- Pair with `remove-safe-to-test.yml` for TOCTOU protection
+
+### 3.2 Post-Merge Security Scan (`security-post-merge.yml`)
+
+For repos where PR security scans are informational but post-merge should
+upload to GitHub Security tab:
+
+- Trigger on push to main (path-filtered to dependency files)
+- Full Trivy scan with SARIF upload
+- `continue-on-error: true` (never blocks main)
+
+### 3.3 TOCTOU Protection (`remove-safe-to-test.yml`)
+
+Pair with comment-triggered E2E:
+
+- Trigger: `pull_request_target` on `synchronize`
+- Remove `safe-to-test` label on new commits
+- Post security checklist comment for maintainers
+
+---
+
+## Action Version Reference
+
+When generating workflows, use the latest SHA-pinned versions. Look up current
+SHAs from the target repo's existing workflows or from well-known action releases as the reference. All
+actions MUST be SHA-pinned with a version comment:
+
+```yaml
+- uses: actions/checkout@<full-sha>  # v4
+```
+
+**Never use tag-only references** like `@v4`.
+
+---
+
+## Skills to Push Alongside
+
+Include in the target's `.claude/skills/`:
+- `ci:status` — Check CI pipeline status
+- `rca:ci` — Root cause analysis from CI logs
+
+---
+
+## Branch and PR Workflow
+
+```bash
+git -C .repos/<target> checkout -b orchestrate/ci
+```
+
+### PR size check
+
+```bash
+git -C .repos/<target> diff --stat | tail -1
+```
+
+Target ~600-700 lines. If over 700, split:
+- PR 3a: `ci.yml` + `dependabot.yml`
+- PR 3b: `security-scans.yml` + `scorecard.yml`
+- PR 3c: Container builds (if applicable)
+
+### Commit and push
+
+```bash
+git -C .repos/<target> add -A
+```
+
+```bash
+git -C .repos/<target> commit -s -m "feat: add comprehensive CI workflows (lint, test, build, security, dependabot, scorecard)"
+```
+
+```bash
+git -C .repos/<target> push -u origin orchestrate/ci
+```
+
+### Create PR
+
+```bash
+gh pr create --repo org/repo --title "Add comprehensive CI workflows" --body "Phase 4 of repo orchestration. Adds GitHub Actions for lint, test, build, security scanning (Trivy, CodeQL, SAST), dependabot for all ecosystems, OpenSSF Scorecard, and action pinning verification."
+```
+
+## Update Phase Status
+
+Set ci to `complete` in `/tmp/kagenti/orchestrate/<target>/phase-status.md`.
+
+## Related Skills
+
+- `orchestrate` — Parent router
+- `orchestrate:tests` — Previous phase (test suite to run in CI)
+- `orchestrate:plan` — Defines CI phase tasks
+- `orchestrate:security` — Next phase: governance hardening
+- `ci:status` — Monitor CI pipelines
+- `rca:ci` — Debug CI failures

--- a/.claude/skills/orchestrate:plan/SKILL.md
+++ b/.claude/skills/orchestrate:plan/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: orchestrate:plan
+description: Brainstorm and create phased enhancement plan for a target repo - PR sizing, phase selection, task breakdown
+---
+
+```mermaid
+flowchart TD
+    START(["/orchestrate:plan"]) --> READ["Read scan report"]:::orch
+    READ --> PRESENT["Present findings"]:::orch
+    PRESENT --> BRAINSTORM["Brainstorm with developer"]:::orch
+    BRAINSTORM --> SELECT["Select applicable phases"]:::orch
+    SELECT --> SIZE["Size PRs (600-700 lines)"]:::orch
+    SIZE --> WRITE["Write plan document"]:::orch
+    WRITE --> DONE([Plan complete])
+
+    classDef orch fill:#FF9800,stroke:#333,color:white
+```
+
+> Follow this diagram as the workflow.
+
+# Orchestrate: Plan
+
+Take the scan report and turn it into a concrete phased enhancement plan. This
+is Phase 1 — interactive brainstorming with the developer, no PRs.
+
+## When to Use
+
+- After `orchestrate:scan` has produced a scan report
+- Before starting any PR-producing phase
+
+## Prerequisites
+
+Scan report must exist:
+
+```bash
+cat /tmp/kagenti/orchestrate/<target>/scan-report.md
+```
+
+## Planning Process
+
+### 1. Read the scan report
+
+Review the Gap Summary and Recommended Phases sections.
+
+### 2. Present findings to developer
+
+Summarize the key gaps in plain language. Use AskUserQuestion to confirm
+understanding and gather context about the repo's priorities.
+
+### 3. Brainstorm which phases apply
+
+Not all repos need all phases. Use AskUserQuestion to decide:
+
+| Gap Found | Phase | Default |
+|-----------|-------|---------|
+| No pre-commit config | `orchestrate:precommit` | Always (foundation) |
+| No/incomplete CI workflows or security scanning | `orchestrate:ci` | Yes if missing |
+| No/few tests (<5 test files) | `orchestrate:tests` | Yes if low coverage |
+| No CODEOWNERS/SECURITY.md/LICENSE | `orchestrate:security` | Recommended |
+| No `.claude/skills/` directory | `orchestrate:replicate` | Always (last phase) |
+
+### 4. Determine phase order
+
+Default order: precommit → tests → ci → security → replicate
+
+Tests come before CI (so CI can run them) and before security (so code
+refactoring for security fixes has test coverage as a safety net). Pre-commit
+is always first (it validates subsequent PRs). Replicate is always last.
+
+### 5. Size PRs
+
+Target 600-700 lines per PR. For each phase:
+- If estimated >700 lines: split into sub-PRs by concern
+- If estimated <300 lines: merge with adjacent phase
+- Skills pushed alongside each phase count toward the total
+
+### 6. Write the plan document
+
+## Plan Output
+
+Save to `/tmp/kagenti/orchestrate/<target>/plan.md`:
+
+```markdown
+# Enhancement Plan: <target>
+
+**Generated from scan:** YYYY-MM-DD
+**Tech stack:** <language>
+**Phases:** <count>
+
+## Phase 2: Pre-commit (PR #1, ~NNN lines)
+- [ ] Add .pre-commit-config.yaml
+- [ ] Add linting config
+- [ ] Create CLAUDE.md
+- [ ] Create .claude/settings.json
+- [ ] Add repo:commit skill
+
+## Phase 3: Tests (PR #2, ~NNN lines)
+- [ ] Set up test framework
+- [ ] Add test configuration
+- [ ] Write initial tests for critical paths
+- [ ] Add test:write and tdd:ci skills
+
+## Phase 4: CI (PR #3, ~NNN lines)
+- [ ] Add lint/test/build workflow (ci.yml)
+- [ ] Add security scanning workflow (security-scans.yml)
+- [ ] Add dependabot.yml (all detected ecosystems)
+- [ ] Add scorecard workflow
+- [ ] Add action pinning verification
+- [ ] Add container build workflow (if Dockerfiles exist)
+- [ ] Add ci:status and rca:ci skills
+
+## Phase 5: Security Governance (PR #4, ~NNN lines)
+- [ ] Create CODEOWNERS
+- [ ] Create SECURITY.md
+- [ ] Create CONTRIBUTING.md
+- [ ] Verify/add LICENSE
+- [ ] Audit .gitignore
+
+## Phase 6: Replicate (PR #5)
+- [ ] Copy orchestrate:* skills to target
+- [ ] Adapt references
+- [ ] Update CLAUDE.md
+- [ ] Validate skills
+```
+
+## After Planning
+
+Initialize phase tracking:
+
+```bash
+cat > /tmp/kagenti/orchestrate/<target>/phase-status.md << 'EOF'
+# Phase Status: <target>
+
+| Phase | Status | PR | Date |
+|-------|--------|----|------|
+| scan | complete | — | YYYY-MM-DD |
+| plan | complete | — | YYYY-MM-DD |
+| precommit | pending | | |
+| tests | pending | | |
+| ci | pending | | |
+| security | pending | | |
+| replicate | pending | | |
+EOF
+```
+
+Then invoke the first applicable phase skill (usually `orchestrate:precommit`).
+
+## Related Skills
+
+- `orchestrate` — Parent router
+- `orchestrate:scan` — Prerequisite: produces the scan report
+- `orchestrate:precommit` — Usually the first PR-producing phase

--- a/.claude/skills/orchestrate:precommit/SKILL.md
+++ b/.claude/skills/orchestrate:precommit/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: orchestrate:precommit
+description: Add pre-commit hooks, linting, CLAUDE.md, and foundational .claude/ setup to a target repo
+---
+
+```mermaid
+flowchart TD
+    START(["/orchestrate:precommit"]) --> DETECT["Detect language"]:::orch
+    DETECT --> PRECOMMIT["Generate .pre-commit-config.yaml"]:::orch
+    PRECOMMIT --> LINT["Generate lint config"]:::orch
+    LINT --> MAKEFILE["Add Makefile targets"]:::orch
+    MAKEFILE --> CLAUDE_MD["Create CLAUDE.md"]:::orch
+    CLAUDE_MD --> SETTINGS["Create .claude/settings.json"]:::orch
+    SETTINGS --> BRANCH["Create branch"]:::orch
+    BRANCH --> SIZE{Under 700 lines?}
+    SIZE -->|Yes| PR["Commit + open PR"]:::orch
+    SIZE -->|No| SPLIT["Split into sub-PRs"]:::orch
+    SPLIT --> PR
+    PR --> DONE([Phase complete])
+
+    classDef orch fill:#FF9800,stroke:#333,color:white
+```
+
+> Follow this diagram as the workflow.
+
+# Orchestrate: Pre-commit
+
+Establish the code quality baseline for a target repo. This is Phase 2 and
+produces PR #1 — the foundation that validates all subsequent PRs.
+
+## When to Use
+
+- After `orchestrate:plan` identifies precommit as a needed phase
+- Always the first PR-producing phase
+
+## Prerequisites
+
+- Plan exists at `/tmp/kagenti/orchestrate/<target>/plan.md`
+- Target repo cloned in `.repos/<target>/`
+
+## Step 1: Detect Language
+
+Use the scan report or check directly:
+
+```bash
+ls .repos/<target>/go.mod .repos/<target>/pyproject.toml .repos/<target>/package.json .repos/<target>/requirements.yml 2>/dev/null
+```
+
+## Step 2: Generate Pre-commit Config
+
+Create `.pre-commit-config.yaml` with language-appropriate hooks.
+
+### Python hooks
+
+- `ruff` — lint + format
+- `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`
+- `check-added-large-files`
+
+### Go hooks
+
+- `golangci-lint`
+- `gofmt`, `govet`
+- `trailing-whitespace`, `end-of-file-fixer`
+
+### Node hooks
+
+- `eslint`, `prettier`
+- `trailing-whitespace`, `end-of-file-fixer`
+
+### Ansible hooks
+
+- `ansible-lint`, `yamllint`
+- `trailing-whitespace`, `end-of-file-fixer`
+
+## Step 3: Generate Lint Config
+
+### Python (`pyproject.toml`)
+
+```toml
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+```
+
+### Go (`.golangci.yml`)
+
+```yaml
+linters:
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - unused
+run:
+  timeout: 5m
+```
+
+### Node (`.eslintrc.json`)
+
+```json
+{
+  "extends": ["eslint:recommended"],
+  "env": { "node": true, "es2022": true }
+}
+```
+
+## Step 4: Add Makefile Targets
+
+If no Makefile exists, create one. If it exists, add targets:
+
+```makefile
+.PHONY: lint fmt
+
+lint:
+	pre-commit run --all-files
+
+fmt:
+	# language-specific formatter command
+```
+
+## Step 5: Create CLAUDE.md
+
+Template for the target repo:
+
+```markdown
+# <Repo Name>
+
+## Overview
+<brief description from README or scan>
+
+## Repository Structure
+<key directories and their purpose>
+
+## Key Commands
+| Task | Command |
+|------|---------|
+| Lint | `make lint` |
+| Format | `make fmt` |
+| Test | <detected test command> |
+| Build | <detected build command> |
+
+## Code Style
+- <language> with <linter>
+- Pre-commit hooks: `pre-commit install`
+- Sign-off required: `git commit -s`
+```
+
+## Step 6: Create .claude/settings.json
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git branch:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(find:*)",
+      "Bash(make lint:*)",
+      "Bash(make fmt:*)",
+      "Bash(pre-commit run:*)"
+    ]
+  }
+}
+```
+
+## Step 7: Create Branch and PR
+
+Create branch in the target repo:
+
+```bash
+git -C .repos/<target> checkout -b orchestrate/precommit
+```
+
+### PR size check
+
+```bash
+git -C .repos/<target> diff --stat | tail -1
+```
+
+Target ~600-700 lines. Split if over 700.
+
+### Skills to push alongside
+
+Include initial skills in `.claude/skills/` within the target repo:
+- `repo:commit` — commit message conventions adapted for the target
+
+### Commit and push
+
+```bash
+git -C .repos/<target> add -A
+```
+
+```bash
+git -C .repos/<target> commit -s -m "feat: add pre-commit hooks, linting, and Claude Code setup"
+```
+
+```bash
+git -C .repos/<target> push -u origin orchestrate/precommit
+```
+
+### Create PR
+
+```bash
+gh pr create --repo org/repo --title "Add pre-commit hooks and code quality baseline" --body "Phase 2 of repo orchestration. Adds pre-commit hooks, linting config, CLAUDE.md, and .claude/ setup."
+```
+
+## Update Phase Status
+
+Update `/tmp/kagenti/orchestrate/<target>/phase-status.md`:
+- Set precommit to `complete`
+- Record PR number and date
+
+## Related Skills
+
+- `orchestrate` — Parent router
+- `orchestrate:scan` — Provides tech stack detection
+- `orchestrate:plan` — Defines precommit phase tasks
+- `orchestrate:tests` — Next phase: test infrastructure

--- a/.claude/skills/orchestrate:replicate/SKILL.md
+++ b/.claude/skills/orchestrate:replicate/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: orchestrate:replicate
+description: Bootstrap orchestrate skills into a target repo - making it self-sufficient for orchestrating its own related repos
+---
+
+```mermaid
+flowchart TD
+    START(["/orchestrate:replicate"]) --> COPY["Copy orchestrate skills"]:::orch
+    COPY --> ADAPT["Adapt references"]:::orch
+    ADAPT --> UPDATE["Update target CLAUDE.md"]:::orch
+    UPDATE --> VALIDATE["Validate skills"]:::orch
+    VALIDATE --> BRANCH["Create branch"]:::orch
+    BRANCH --> PR["Commit + open PR"]:::orch
+    PR --> DONE([Target self-sufficient])
+
+    classDef orch fill:#FF9800,stroke:#333,color:white
+```
+
+> Follow this diagram as the workflow.
+
+# Orchestrate: Replicate
+
+The final orchestration phase. Copies orchestrate skills into the target repo,
+making it fully self-sufficient. This is Phase 6.
+
+## When to Use
+
+- Final phase of orchestration
+- After at least precommit + CI phases are complete
+- When you want the target repo to orchestrate its own related repos
+
+## Prerequisites
+
+- `orchestrate:precommit` and `orchestrate:ci` complete (at minimum)
+- Target repo has `.claude/` directory
+
+## What Gets Copied
+
+| Skill | Purpose |
+|-------|---------|
+| `orchestrate/` | Router — entry point |
+| `orchestrate:scan/` | Assess repos |
+| `orchestrate:plan/` | Create phased plans |
+| `orchestrate:precommit/` | Add pre-commit hooks |
+| `orchestrate:ci/` | Add CI workflows |
+| `orchestrate:tests/` | Add test infrastructure |
+| `orchestrate:security/` | Add security hardening |
+| `orchestrate:replicate/` | This skill (self!) |
+| `skills:scan/` | Discover skills in a repo |
+| `skills:write/` | Author new skills |
+| `skills:validate/` | Validate skill structure |
+
+## Adaptation Steps
+
+After copying, adapt the skills:
+
+1. **Remove source-specific references** — strip kagenti-specific paths or
+   assumptions that don't apply
+2. **Verify frontmatter** — every `name:` field must match its directory name
+3. **Update Related Skills** — only reference skills that exist in the copied set
+4. **Preserve generality** — skills should work in any repo context
+
+## Update Target CLAUDE.md
+
+Add an orchestration section:
+
+```markdown
+## Orchestration
+
+This repo includes orchestrate skills for enhancing related repos:
+
+| Skill | Description |
+|-------|-------------|
+| `orchestrate` | Run `/orchestrate <repo-path>` to start |
+| `orchestrate:scan` | Assess repo structure and gaps |
+| `orchestrate:plan` | Create phased enhancement plan |
+| `orchestrate:replicate` | Bootstrap skills into target |
+```
+
+## The Fractal Concept
+
+This phase makes the system self-replicating:
+
+1. **Repo A** orchestrates **Repo B** through all phases
+2. Phase 6 copies orchestrate skills into **Repo B**
+3. **Repo B** can now orchestrate **Repo C**
+4. **Repo C** can orchestrate **Repo D**, and so on
+
+Each copy is independent. No runtime dependency on the original hub. The
+skills adapt to whatever tech stack the scan discovers.
+
+## Validation
+
+After copying, verify:
+
+1. **Frontmatter match** — `name:` matches directory for each skill
+2. **No broken references** — Related Skills point to existing skills
+3. **No source-specific content** — grep for original repo name
+4. **Structure** — every directory has exactly one `SKILL.md`
+
+## Branch and PR Workflow
+
+```bash
+git -C .repos/<target> checkout -b orchestrate/replicate
+```
+
+```bash
+git -C .repos/<target> add .claude/skills/orchestrate* .claude/skills/skills*
+```
+
+```bash
+git -C .repos/<target> commit -s -m "feat: bootstrap orchestrate skills for self-sufficient orchestration"
+```
+
+```bash
+git -C .repos/<target> push -u origin orchestrate/replicate
+```
+
+## Related Skills
+
+- `orchestrate` — Parent router
+- `orchestrate:security` — Previous phase
+- `skills:scan` — Discover skills (gets copied)
+- `skills:write` — Author skills (gets copied)
+- `skills:validate` — Validate skills (gets copied)

--- a/.claude/skills/orchestrate:scan/SKILL.md
+++ b/.claude/skills/orchestrate:scan/SKILL.md
@@ -1,0 +1,523 @@
+---
+name: orchestrate:scan
+description: Scan and assess a target repository - tech stack, CI maturity, security posture, test coverage, supply chain health
+---
+
+```mermaid
+flowchart TD
+    START(["/orchestrate:scan"]) --> TECH["Detect tech stack"]:::orch
+    TECH --> CI["Check CI maturity"]:::orch
+    CI --> SEC_SCAN["Check security scanning"]:::orch
+    SEC_SCAN --> DEPS["Check dependency management"]:::orch
+    DEPS --> TESTS["Check test coverage"]:::orch
+    TESTS --> SUPPLY["Check supply chain health"]:::orch
+    SUPPLY --> CVE["Run cve:scan"]:::cve
+    CVE --> SEC_GOV["Check security governance"]:::orch
+    SEC_GOV --> CLAUDE["Check Claude Code readiness"]:::orch
+    CLAUDE --> REPORT["Generate scan report"]:::orch
+    REPORT --> DONE([Scan complete])
+
+    classDef orch fill:#FF9800,stroke:#333,color:white
+    classDef cve fill:#D32F2F,stroke:#333,color:white
+```
+
+> Follow this diagram as the workflow.
+
+# Orchestrate: Scan
+
+Assess a target repository's current state to determine what orchestration
+phases are needed. This is Phase 0 — produces artifacts only, no PRs.
+
+## When to Use
+
+- First step when orchestrating a new repo
+- Re-run after major changes to reassess gaps
+- Before running `orchestrate:plan`
+
+## Prerequisites
+
+Target repo cloned into `.repos/<target>/`:
+
+```bash
+git clone git@github.com:org/repo.git .repos/<target>
+```
+
+## Technology Detection
+
+Check for marker files to identify the tech stack:
+
+```bash
+ls .repos/<target>/go.mod .repos/<target>/pyproject.toml .repos/<target>/package.json .repos/<target>/Cargo.toml .repos/<target>/requirements.yml 2>/dev/null
+```
+
+| Marker | Language | Lint Tool | Test Tool | Build Tool |
+|--------|----------|-----------|-----------|------------|
+| `go.mod` | Go | golangci-lint | go test | go build |
+| `pyproject.toml` | Python | ruff | pytest | uv build |
+| `package.json` | Node.js | eslint | jest/vitest | npm build |
+| `Cargo.toml` | Rust | clippy | cargo test | cargo build |
+| `requirements.yml` | Ansible | ansible-lint | molecule | — |
+
+For multi-language repos (e.g., Go + Python + Helm), note all detected stacks.
+
+Also check for:
+- Dockerfiles: `find .repos/<target> -name "Dockerfile*" -type f`
+- Helm charts: `find .repos/<target> -name "Chart.yaml" -type f`
+- Shell scripts: `find .repos/<target> -name "*.sh" -type f`
+- Makefiles: `ls .repos/<target>/Makefile`
+
+## Scan Checks
+
+### CI Status
+
+```bash
+ls .repos/<target>/.github/workflows/ 2>/dev/null
+```
+
+For each workflow found, read it and categorize:
+
+| Category | What to Check |
+|----------|---------------|
+| Lint | Does a workflow run linters? Which ones? |
+| Test | Does a workflow run tests? Are they commented out? |
+| Build | Does a workflow build artifacts/images? |
+| Security | Does a workflow run security scans? |
+| Release | Does a workflow handle releases/tags? |
+
+### Security Scanning Coverage
+
+Check which security tools are configured in CI:
+
+| Tool | How to Detect | Purpose |
+|------|---------------|---------|
+| Trivy | `trivy-action` in workflows | Filesystem/container/IaC scanning |
+| CodeQL | `codeql-action` in workflows | SAST for supported languages |
+| Bandit | `bandit` in workflows or pre-commit | Python SAST |
+| gosec | `gosec` in workflows | Go SAST |
+| Hadolint | `hadolint` in workflows or pre-commit | Dockerfile linting |
+| Shellcheck | `shellcheck` in workflows or pre-commit | Shell script linting |
+| Dependency review | `dependency-review-action` in workflows | PR dependency audit |
+| Scorecard | `scorecard-action` in workflows | OpenSSF supply chain |
+| Gitleaks | `gitleaks` in workflows or pre-commit | Secret detection |
+
+Score: count how many of the applicable tools are present vs expected.
+
+### Dependency Management
+
+```bash
+cat .repos/<target>/.github/dependabot.yml 2>/dev/null || echo "MISSING"
+```
+
+Check which ecosystems are covered vs what's in the repo:
+
+| In Repo | Expected Ecosystem | Covered? |
+|---------|-------------------|----------|
+| `pyproject.toml` | pip | ? |
+| `go.mod` | gomod | ? |
+| `package.json` | npm | ? |
+| `Dockerfile` | docker | ? |
+| `.github/workflows/` | github-actions | ? |
+
+### Action Pinning Compliance
+
+```bash
+grep -r "uses:" .repos/<target>/.github/workflows/ 2>/dev/null | grep -v "@[a-f0-9]\{40\}" | head -20
+```
+
+Count actions pinned to SHA vs tag-only. Report compliance percentage.
+
+### Permissions Model
+
+Check workflow files for:
+- Top-level `permissions: {}` or `permissions: read-all` (good)
+- Per-job `permissions:` blocks (good)
+- No permissions declaration (bad — gets full default token permissions)
+
+```bash
+grep -l "^permissions:" .repos/<target>/.github/workflows/*.yml 2>/dev/null
+```
+
+### Test Coverage
+
+Categorize tests into 4 areas. For each, detect frameworks, count files/functions,
+check coverage tooling, and verify CI execution.
+
+#### Backend Tests
+
+Detect framework from marker files:
+
+```bash
+# Python
+grep -q "pytest" .repos/<target>/pyproject.toml 2>/dev/null && echo "pytest"
+# Go
+ls .repos/<target>/go.mod 2>/dev/null && echo "go test"
+# Go + Ginkgo
+grep -q "ginkgo" .repos/<target>/go.mod 2>/dev/null && echo "ginkgo"
+```
+
+Count test files and functions:
+
+```bash
+find .repos/<target> -type f -name "test_*.py" -o -name "*_test.py" 2>/dev/null | wc -l
+find .repos/<target> -type f -name "*_test.go" 2>/dev/null | wc -l
+grep -rc "def test_\|func Test" .repos/<target> --include="*.py" --include="*.go" 2>/dev/null | awk -F: '{s+=$2} END {print s}'
+```
+
+Check coverage tooling:
+
+```bash
+# Python: pytest-cov in dependencies
+grep -q "pytest-cov" .repos/<target>/pyproject.toml 2>/dev/null && echo "pytest-cov found"
+# Python: coverage config
+grep -q "\[tool.coverage" .repos/<target>/pyproject.toml 2>/dev/null && echo "coverage config found"
+# Go: -coverprofile in Makefile or CI
+grep -r "\-coverprofile" .repos/<target>/Makefile .repos/<target>/.github/workflows/ 2>/dev/null
+```
+
+When coverage tooling is missing, recommend the appropriate tool:
+- Python: add `pytest-cov>=4.0` to dev deps and `[tool.coverage.run] source = ["src"]` to pyproject.toml
+- Go: add `-coverprofile=coverage.out` to `go test` invocation in Makefile/CI
+
+#### UI Tests
+
+Detect framework from package.json:
+
+```bash
+grep -E "playwright|jest|vitest" .repos/<target>/*/package.json .repos/<target>/package.json 2>/dev/null
+```
+
+Count spec files and test blocks:
+
+```bash
+find .repos/<target> -type f \( -name "*.spec.ts" -o -name "*.spec.tsx" -o -name "*.test.ts" -o -name "*.test.tsx" \) 2>/dev/null | wc -l
+grep -rc "test(\|it(\|describe(" .repos/<target> --include="*.spec.*" --include="*.test.*" 2>/dev/null | awk -F: '{s+=$2} END {print s}'
+```
+
+Note: for Playwright E2E-style UI tests, code coverage is typically not applicable.
+For unit-test-style UI tests (jest/vitest), check for istanbul/c8 coverage config.
+
+#### E2E Tests
+
+Count test files and functions:
+
+```bash
+find .repos/<target> -path "*/e2e/*" -type f -name "test_*.py" 2>/dev/null | wc -l
+grep -rc "def test_" .repos/<target>/*/tests/e2e/ .repos/<target>/tests/e2e/ 2>/dev/null | awk -F: '{s+=$2} END {print s}'
+```
+
+Build a feature coverage map by scanning test filenames and imports:
+
+```bash
+# List E2E test files to identify which features are covered
+find .repos/<target> -path "*/e2e/*" -name "test_*.py" -exec basename {} \; 2>/dev/null | sort
+```
+
+Map each test file to a platform feature (e.g., `test_keycloak.py` → Keycloak auth,
+`test_shipwright_build.py` → Shipwright builds). Identify features present in the
+codebase that lack E2E tests.
+
+Build a CI trigger matrix:
+
+```bash
+# Which workflows run E2E tests, on which triggers and platforms?
+grep -l "e2e\|E2E" .repos/<target>/.github/workflows/*.yml 2>/dev/null
+```
+
+For each E2E workflow, note the trigger events (push/PR/manual) and target
+platforms (Kind/OCP/HyperShift).
+
+#### Infra Tests
+
+Infra testing is about variant coverage, not code coverage. Score as a variant matrix.
+
+Scan for deployment targets:
+
+```bash
+# Which platforms appear in CI workflows and scripts?
+grep -rl "kind\|Kind\|KIND" .repos/<target>/.github/workflows/ 2>/dev/null
+grep -rl "openshift\|OpenShift\|OCP" .repos/<target>/.github/workflows/ 2>/dev/null
+grep -rl "hypershift\|HyperShift" .repos/<target>/.github/workflows/ 2>/dev/null
+```
+
+Scan values files for toggle combos:
+
+```bash
+# Which feature toggles exist in Helm values files?
+find .repos/<target> -path "*/envs/*" -name "values*.yaml" 2>/dev/null
+# Check for toggle patterns
+grep -r "enabled:" .repos/<target>/deployments/envs/ .repos/<target>/charts/*/values.yaml 2>/dev/null | head -20
+```
+
+Check static validation in CI:
+
+```bash
+grep -rl "helm lint\|helm template" .repos/<target>/.github/workflows/ 2>/dev/null && echo "helm lint: in CI"
+grep -rl "shellcheck" .repos/<target>/.github/workflows/ .repos/<target>/.pre-commit-config.yaml 2>/dev/null && echo "shellcheck: in CI"
+grep -rl "hadolint" .repos/<target>/.github/workflows/ .repos/<target>/.pre-commit-config.yaml 2>/dev/null && echo "hadolint: in CI"
+grep -rl "yamllint" .repos/<target>/.github/workflows/ .repos/<target>/.pre-commit-config.yaml 2>/dev/null && echo "yamllint: in CI"
+```
+
+### CVE Scan
+
+Invoke `cve:scan` against the target repo to detect known vulnerabilities in
+dependencies. This runs the full cve:scan procedure (inventory → Trivy → LLM +
+WebSearch → findings report).
+
+The scan operates on the target repo working directory:
+
+```bash
+cd .repos/<target>
+```
+
+Then follow the `cve:scan` skill workflow:
+1. **Inventory** — find all dependency files (pyproject.toml, go.mod, package.json,
+   Dockerfile, Chart.yaml, requirements*.txt, uv.lock)
+2. **Trivy** (if installed) — filesystem scan with `--severity HIGH,CRITICAL`
+3. **LLM + WebSearch** — cross-reference dependencies against NVD/OSV/GitHub
+   Advisory Database
+4. **Classify** — confirmed / suspected / false positive
+
+Write CVE findings to `/tmp/kagenti/cve/<target>/scan-report.json` (never to
+git-tracked files). Include a summary in the scan report.
+
+Key areas to focus on:
+- Crypto/auth libraries (cryptography, pyjwt, golang.org/x/crypto, oauth2)
+- Network libraries (httpx, requests, grpcio, golang.org/x/net)
+- Serialization (protobuf, pydantic)
+- Container base images (EOL versions, unpinned tags)
+- Abandoned/deprecated libraries (e.g., dgrijalva/jwt-go)
+
+### Pre-commit Hooks
+
+```bash
+cat .repos/<target>/.pre-commit-config.yaml 2>/dev/null
+```
+
+If present, list which hooks are configured.
+
+### Security Governance
+
+```bash
+ls .repos/<target>/CODEOWNERS .repos/<target>/.github/CODEOWNERS 2>/dev/null
+ls .repos/<target>/SECURITY.md 2>/dev/null
+ls .repos/<target>/CONTRIBUTING.md 2>/dev/null
+ls .repos/<target>/LICENSE 2>/dev/null
+```
+
+### Claude Code Readiness
+
+```bash
+ls .repos/<target>/CLAUDE.md .repos/<target>/.claude/settings.json 2>/dev/null
+```
+
+```bash
+ls .repos/<target>/.claude/skills/ 2>/dev/null
+```
+
+### Git Health
+
+```bash
+git -C .repos/<target> log --oneline -5
+```
+
+```bash
+git -C .repos/<target> remote -v
+```
+
+## Output Format
+
+Save scan report to `/tmp/kagenti/orchestrate/<target>/scan-report.md`:
+
+```bash
+mkdir -p /tmp/kagenti/orchestrate/<target>
+```
+
+Report template:
+
+```markdown
+# Scan Report: <target>
+
+**Date:** YYYY-MM-DD
+**Tech Stack:** <languages, frameworks>
+**Maturity Score:** N/5
+
+## CI Status
+- Workflows found: [list or "none"]
+- Covers: lint / test / build / security / release
+- Tests in CI: running / commented out / missing
+
+## Security Scanning
+| Tool | Status | Notes |
+|------|--------|-------|
+| Trivy | present/missing | |
+| CodeQL | present/missing/n-a | |
+| Bandit/gosec | present/missing/n-a | |
+| Hadolint | present/missing/n-a | |
+| Shellcheck | present/missing/n-a | |
+| Dependency review | present/missing | |
+| Scorecard | present/missing | |
+| Gitleaks | present/missing | |
+
+## Dependency Management
+- Dependabot config: yes/no
+- Ecosystems covered: [list]
+- Ecosystems missing: [list]
+
+## Supply Chain Health
+- Action pinning: N% SHA-pinned (N/M actions)
+- Permissions model: least-privilege / default / mixed
+- Unpinned actions: [list top offenders]
+
+## Test Coverage
+
+### Backend Tests
+- Framework: [pytest X.x / go test / ginkgo vX.x / none]
+- Test files: N
+- Test functions: ~M
+- Coverage tool: [pytest-cov / -coverprofile / missing]
+- Coverage config: [present / missing (recommend: ...)]
+- CI execution: [running in workflow.yaml / missing]
+
+### UI Tests
+- Framework: [Playwright X.x / jest / vitest / none]
+- Spec files: N
+- Test blocks: ~M
+- Coverage tool: [istanbul / c8 / n/a (E2E)]
+- CI execution: [running in workflow.yaml / missing]
+
+### E2E Tests
+- Test files: N
+- Test functions: ~M
+- Feature coverage:
+  | Feature | Test File | Status |
+  |---------|-----------|--------|
+  | [feature] | [test file] | covered/missing |
+- CI trigger matrix:
+  | Platform | Push | PR | Manual |
+  |----------|------|-----|--------|
+  | [platform] | [workflow] | [workflow] | — |
+
+### Infra Tests
+- Deployment variants tested:
+  | Variant | CI Workflow | Values File |
+  |---------|------------|-------------|
+  | [platform + version] | [workflow] | [values file] |
+- Value variant coverage:
+  | Feature Toggle | Tested On | Tested Off |
+  |---------------|-----------|------------|
+  | [toggle] | [platforms] | [platforms or —] |
+- Static validation:
+  | Check | Status |
+  |-------|--------|
+  | Helm lint | in CI / missing |
+  | shellcheck | in CI / missing |
+  | hadolint | in CI / missing / n-a |
+  | yamllint | in CI / missing |
+
+## Pre-commit
+- Config found: yes/no
+- Hooks: [list or "none"]
+
+## Security Governance
+- CODEOWNERS: yes/no
+- SECURITY.md: yes/no
+- CONTRIBUTING.md: yes/no
+- LICENSE: yes/no (type if present)
+- .gitignore secrets patterns: adequate/needs-review
+
+## Claude Code Readiness
+- CLAUDE.md: yes/no
+- .claude/settings.json: yes/no
+- Skills count: N
+
+## Container Infrastructure
+- Dockerfiles: N found [list paths]
+- Multi-arch builds: yes/no
+- Container registry: [ghcr.io/etc or "none"]
+- Base image pinning: digest / tag / unpinned
+- EOL base images: [list or "none"]
+
+## Dependency Vulnerabilities (cve:scan)
+- Scan method: [Trivy + LLM + WebSearch / LLM + WebSearch / LLM only]
+- Full report: `/tmp/kagenti/cve/<target>/scan-report.json`
+
+| Severity | Count |
+|----------|-------|
+| CRITICAL | N |
+| HIGH | N |
+| MEDIUM | N |
+| Suspected | N |
+
+### Confirmed Findings
+| Package | Version | Severity | Issue | Fix |
+|---------|---------|----------|-------|-----|
+| [package] | [version] | CRITICAL/HIGH | [brief description — no CVE IDs in public output] | [fixed version or action] |
+
+### Architectural Security Concerns
+| Concern | Severity | Details |
+|---------|----------|---------|
+| [e.g., insecure port, no input validation] | HIGH/MEDIUM | [brief description] |
+
+> **Note:** CVE IDs and detailed descriptions are in `/tmp/kagenti/cve/<target>/scan-report.json` only.
+> Do NOT copy CVE IDs into git-tracked files, PRs, or issues.
+
+## Gap Summary
+| Area | Status | Action Needed |
+|------|--------|---------------|
+| Pre-commit | missing/partial/ok | orchestrate:precommit |
+| Tests (backend) | missing/partial/ok | orchestrate:tests |
+| Tests (UI) | missing/partial/ok/n-a | orchestrate:tests |
+| Tests (E2E) | missing/partial/ok | orchestrate:tests |
+| Tests (infra) | missing/partial/ok | orchestrate:ci |
+| CI (lint/test/build) | missing/partial/ok | orchestrate:ci |
+| CI (security scanning) | missing/partial/ok | orchestrate:ci |
+| CI (dependabot) | missing/partial/ok | orchestrate:ci |
+| CI (scorecard) | missing/partial/ok | orchestrate:ci |
+| CI (supply chain) | missing/partial/ok | orchestrate:ci |
+| Dep vulnerabilities | clean/findings/critical | cve:brainstorm / dep bump |
+| Container base images | pinned/unpinned/eol | orchestrate:ci |
+| Governance | missing/partial/ok | orchestrate:security |
+| Skills | missing/partial/ok | orchestrate:replicate |
+
+## Recommended Phases
+1. [ordered list of phases based on gaps]
+```
+
+## Gap Analysis
+
+Determine which phases are needed based on findings:
+
+| Finding | Phase Needed |
+|---------|-------------|
+| No `.pre-commit-config.yaml` | `orchestrate:precommit` |
+| No CI workflows or missing lint/test | `orchestrate:ci` |
+| No security scanning in CI | `orchestrate:ci` |
+| Dependabot missing or incomplete | `orchestrate:ci` |
+| No scorecard workflow | `orchestrate:ci` |
+| Actions not SHA-pinned | `orchestrate:ci` |
+| Permissions not least-privilege | `orchestrate:ci` |
+| No backend test files or <5 test functions | `orchestrate:tests` |
+| Backend coverage tool missing | `orchestrate:tests` |
+| No UI test specs (when UI code exists) | `orchestrate:tests` |
+| No E2E tests or low feature coverage | `orchestrate:tests` |
+| E2E tests not triggered in CI | `orchestrate:ci` |
+| Only one deployment variant tested | `orchestrate:ci` |
+| Missing static validation (helm lint, shellcheck, etc.) | `orchestrate:ci` |
+| Confirmed CRITICAL/HIGH CVEs in dependencies | `cve:brainstorm` (fix before public issues) |
+| Abandoned/deprecated libraries | dependency bump PR |
+| EOL container base images | `orchestrate:ci` |
+| Unpinned container base image tags | `orchestrate:ci` |
+| No CODEOWNERS or SECURITY.md | `orchestrate:security` |
+| No LICENSE | `orchestrate:security` |
+| No `.claude/skills/` | `orchestrate:replicate` |
+
+All repos get `orchestrate:precommit` (foundation) and `orchestrate:replicate`
+(self-sufficiency). Other phases depend on the scan results.
+
+## Related Skills
+
+- `orchestrate` — Parent router
+- `orchestrate:plan` — Next step: create phased plan from scan results
+- `cve:scan` — Dependency vulnerability scanning (invoked during this scan)
+- `cve:brainstorm` — Disclosure planning when CRITICAL/HIGH CVEs are found
+- `skills:scan` — Similar pattern for scanning skills specifically

--- a/.claude/skills/orchestrate:security/SKILL.md
+++ b/.claude/skills/orchestrate:security/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: orchestrate:security
+description: Add security governance to a target repo - CODEOWNERS, SECURITY.md, CONTRIBUTING.md, LICENSE, .gitignore audit
+---
+
+```mermaid
+flowchart TD
+    START(["/orchestrate:security"]) --> READ["Read plan + scan report"]:::orch
+    READ --> CODEOWNERS["Create CODEOWNERS"]:::orch
+    CODEOWNERS --> SECURITY_MD["Create SECURITY.md"]:::orch
+    SECURITY_MD --> CONTRIBUTING["Create CONTRIBUTING.md"]:::orch
+    CONTRIBUTING --> LICENSE["Verify/add LICENSE"]:::orch
+    LICENSE --> GITIGNORE["Audit .gitignore"]:::orch
+    GITIGNORE --> BRANCH_PROT["Document branch protection"]:::orch
+    BRANCH_PROT --> BRANCH["Create branch"]:::orch
+    BRANCH --> SIZE{Under 700 lines?}
+    SIZE -->|Yes| PR["Commit + open PR"]:::orch
+    SIZE -->|No| SPLIT["Split into sub-PRs"]:::orch
+    SPLIT --> PR
+    PR --> DONE([Phase complete])
+
+    classDef orch fill:#FF9800,stroke:#333,color:white
+```
+
+> Follow this diagram as the workflow.
+
+# Orchestrate: Security Governance
+
+Add security governance files to a target repository. This is Phase 5 and
+produces PR #4. Focuses on governance and policy files — CI-related security
+(scanning, dependabot, scorecard) is handled by `orchestrate:ci`.
+
+## When to Use
+
+- After `orchestrate:plan` identifies security governance as a needed phase
+- After precommit, tests, and CI phases
+
+## Prerequisites
+
+- Plan exists with security phase
+- Scan report exists (to know what's missing)
+- Target repo in `.repos/<target>/`
+
+## Step 1: CODEOWNERS
+
+Create `CODEOWNERS` at repo root or `.github/CODEOWNERS`:
+
+```
+# Default owners for everything
+* @org/team-leads
+
+# Platform and CI
+.github/ @org/platform
+Makefile @org/platform
+
+# Documentation
+docs/ @org/docs-team
+*.md @org/docs-team
+```
+
+Adapt teams and paths based on:
+- The scan report's identified tech stack
+- The org's team structure (check other repos for patterns)
+- Key directories that need specialized review
+
+## Step 2: SECURITY.md
+
+Create `SECURITY.md` with vulnerability reporting guidance:
+
+```markdown
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities through GitHub Security Advisories:
+**[Report a vulnerability](https://github.com/org/repo/security/advisories/new)**
+
+Do NOT open public issues for security vulnerabilities.
+
+## Response Timeline
+
+- **Acknowledgment:** Within 48 hours
+- **Initial assessment:** Within 7 days
+- **Fix timeline:** Based on severity
+
+## Security Controls
+
+This repository uses:
+- CI security scanning (Trivy, CodeQL)
+- Dependency updates via Dependabot
+- OpenSSF Scorecard monitoring
+- Pre-commit hooks for local checks
+```
+
+Adapt the security controls list based on what `orchestrate:ci` actually
+deployed to this repo.
+
+## Step 3: CONTRIBUTING.md
+
+Create `CONTRIBUTING.md` with development workflow:
+
+```markdown
+# Contributing
+
+## Development Setup
+
+[Adapt to tech stack from scan report]
+
+## Pull Request Process
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes with tests
+4. Run pre-commit hooks: `pre-commit run --all-files`
+5. Submit a pull request
+
+## Commit Messages
+
+Use conventional commit format:
+- `feat:` New features
+- `fix:` Bug fixes
+- `docs:` Documentation changes
+- `chore:` Maintenance tasks
+
+All commits must be signed off (`git commit -s`).
+
+## Code of Conduct
+
+[Link to org-level CoC if exists]
+```
+
+## Step 4: LICENSE
+
+Check if LICENSE exists. If missing:
+- Check the org's standard license (most kagenti repos use Apache 2.0)
+- Add the appropriate LICENSE file
+- If unsure, flag in the PR for maintainer decision
+
+## Step 5: .gitignore Audit
+
+Check for missing patterns and add them:
+
+**Secrets and credentials:**
+- `.env`, `.env.*`, `.env.local`
+- `*.key`, `*.pem`, `*.p12`, `*.jks`
+- `credentials.*`, `secrets.*`
+- `kubeconfig`, `*kubeconfig*`
+
+**IDE and OS files:**
+- `.idea/`, `.vscode/`
+- `.DS_Store`, `Thumbs.db`
+
+**Build artifacts (language-specific):**
+- Python: `__pycache__/`, `*.pyc`, `.ruff_cache/`, `dist/`, `*.egg-info/`
+- Go: binary names from `go.mod` module path
+- Node: `node_modules/`, `dist/`, `.next/`
+
+Do not remove existing patterns. Only add missing ones.
+
+## Step 6: Branch Protection Documentation
+
+Document in the PR description (can't auto-apply via PR):
+
+**Recommended branch protection rules for `main`:**
+- Require PR reviews (minimum 1 approval)
+- Require status checks to pass (list the CI checks from `orchestrate:ci`)
+- Require signed commits (if org policy)
+- Disable force push to main
+- Require branches to be up to date before merging
+- Require conversation resolution before merging
+
+## Branch and PR Workflow
+
+```bash
+git -C .repos/<target> checkout -b orchestrate/security
+```
+
+### PR size check
+
+```bash
+git -C .repos/<target> diff --stat | tail -1
+```
+
+### Commit and push
+
+```bash
+git -C .repos/<target> add -A
+```
+
+```bash
+git -C .repos/<target> commit -s -m "feat: add security governance (CODEOWNERS, SECURITY.md, CONTRIBUTING.md, .gitignore)"
+```
+
+```bash
+git -C .repos/<target> push -u origin orchestrate/security
+```
+
+### Create PR
+
+```bash
+gh pr create --repo org/repo --title "Add security governance files" --body "Phase 5 of repo orchestration. Adds CODEOWNERS, SECURITY.md, CONTRIBUTING.md, LICENSE verification, and .gitignore hardening."
+```
+
+## Update Phase Status
+
+Set security to `complete` in phase-status.md.
+
+## Related Skills
+
+- `orchestrate` — Parent router
+- `orchestrate:ci` — Previous phase (CI-related security is there)
+- `orchestrate:plan` — Defines security phase tasks
+- `orchestrate:replicate` — Next phase: bootstrap skills

--- a/.claude/skills/orchestrate:tests/SKILL.md
+++ b/.claude/skills/orchestrate:tests/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: orchestrate:tests
+description: Add test infrastructure and initial test coverage to a target repo
+---
+
+```mermaid
+flowchart TD
+    START(["/orchestrate:tests"]) --> READ["Read plan"]:::orch
+    READ --> DETECT["Detect test framework"]:::orch
+    DETECT --> CONFIG["Create test config"]:::orch
+    CONFIG --> CRITICAL["Identify critical paths"]:::orch
+    CRITICAL --> WRITE["Write initial tests"]:::orch
+    WRITE --> BRANCH["Create branch"]:::orch
+    BRANCH --> SIZE{Under 700 lines?}
+    SIZE -->|Yes| PR["Commit + open PR"]:::orch
+    SIZE -->|No| SPLIT["Split into sub-PRs"]:::orch
+    SPLIT --> PR
+    PR --> DONE([Phase complete])
+
+    classDef orch fill:#FF9800,stroke:#333,color:white
+```
+
+> Follow this diagram as the workflow.
+
+# Orchestrate: Tests
+
+Add test infrastructure and initial test coverage. This is Phase 3 and
+produces PR #2. Tests come before CI and security — good test coverage is
+a safety net for the code refactoring that security/quality fixes require.
+
+## When to Use
+
+- After `orchestrate:plan` identifies tests as a needed phase
+- After precommit phase (linting is the foundation)
+
+## Prerequisites
+
+- Plan exists with tests phase
+- Target repo in `.repos/<target>/`
+
+## Step 1: Detect Test Framework
+
+| Marker | Language | Framework | Assertion |
+|--------|----------|-----------|-----------|
+| `pyproject.toml` | Python | pytest | built-in assert |
+| `go.mod` | Go | testing (stdlib) | testify |
+| `package.json` | Node | jest or vitest | built-in expect |
+| `requirements.yml` | Ansible | molecule | testinfra |
+
+Check existing tests:
+
+```bash
+find .repos/<target> -type f \( -name "test_*.py" -o -name "*_test.go" -o -name "*.test.*" \) 2>/dev/null
+```
+
+## Step 2: Create Test Configuration
+
+### Python
+
+- `tests/conftest.py` — shared fixtures
+- `tests/__init__.py` — package marker
+- `pyproject.toml` — add `[tool.pytest.ini_options]` with `testpaths = ["tests"]`
+
+### Go
+
+- `*_test.go` files alongside source
+- `testdata/` for fixtures
+- `internal/testutil/` for shared helpers
+
+### Node
+
+- `jest.config.ts` or `vitest.config.ts` at root
+- `__tests__/` directory or `*.test.ts` alongside source
+
+### Ansible
+
+- `molecule/default/` with `molecule.yml`, `converge.yml`, `verify.yml`
+
+## Step 3: Identify Critical Paths
+
+From the scan report, find highest-impact areas:
+
+1. **API endpoints** — HTTP handlers, REST routes
+2. **Core logic** — main algorithms, data transformations
+3. **Integration points** — database, external APIs
+4. **Config parsing** — loading, validation, defaults
+5. **Error handling** — paths affecting users or data
+
+Prioritize smoke tests across areas over exhaustive coverage of one area.
+
+## Step 4: Write Initial Tests
+
+### Strategy
+
+- Start with smoke tests (happy path)
+- Add edge cases for most critical functions
+- Target 5-15 test functions
+- Do not aim for 100% coverage
+- Each test must be independent
+
+### Test naming
+
+| Language | Convention | Example |
+|----------|-----------|---------|
+| Python | `test_<what>_<condition>` | `test_create_user_returns_201` |
+| Go | `Test<What><Condition>` | `TestCreateUserReturns201` |
+| Node | `describe/it` blocks | `it('returns 201 when creating user')` |
+
+### Test structure (AAA)
+
+1. **Arrange** — set up test data
+2. **Act** — call function under test
+3. **Assert** — verify with specific assertions
+
+## Step 5: Branch and PR
+
+```bash
+git -C .repos/<target> checkout -b orchestrate/tests
+```
+
+### PR size check
+
+```bash
+git -C .repos/<target> diff --stat | tail -1
+```
+
+If over 700 lines, split: framework setup in PR #3a, tests in PR #3b.
+
+### Skills to push alongside
+
+- `test:write` — guide for writing new tests
+- `tdd:ci` — workflow for iterating on CI test failures
+
+### Commit and push
+
+```bash
+git -C .repos/<target> add -A
+```
+
+```bash
+git -C .repos/<target> commit -s -m "feat: add test infrastructure and initial test coverage"
+```
+
+```bash
+git -C .repos/<target> push -u origin orchestrate/tests
+```
+
+## Update Phase Status
+
+Set tests to `complete` in phase-status.md.
+
+## Related Skills
+
+- `orchestrate` — Parent router
+- `orchestrate:precommit` — Previous phase (linting foundation)
+- `orchestrate:plan` — Defines test phase tasks
+- `orchestrate:ci` — Next phase (automates running these tests)
+- `test:write` — Detailed test writing guide
+- `tdd:ci` — CI-driven TDD workflow

--- a/.claude/skills/skills:scan/SKILL.md
+++ b/.claude/skills/skills:scan/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: skills:scan
+description: Scan a repository to bootstrap new skills or audit and update existing ones
+---
+
+# Scan Repository for Skills
+
+Bootstrap skills for a new repo, or audit and update skills in an existing one.
+
+```mermaid
+flowchart TD
+    START(["/skills:scan"]) --> MODE{"Repo has skills?"}
+    MODE -->|No| NP1["Analyze Repo"]:::skills
+    MODE -->|Yes| EP1["Validate Existing"]:::skills
+
+    NP1 --> NP2["Identify Categories"]:::skills
+    NP2 --> NP3["Generate Core Skills"]:::skills
+    NP3 --> NP4["Generate settings.json"]:::skills
+    NP4 --> DONE([Skills bootstrapped])
+
+    EP1 --> EP2["Gap Analysis"]:::skills
+    EP2 --> EP3["Content Quality"]:::skills
+    EP3 --> EP4["Connection Analysis"]:::skills
+    EP4 --> EP5["Usefulness Rating"]:::skills
+    EP5 --> EP6["Generate Report"]:::skills
+    EP6 --> EP7["Update README"]:::skills
+
+    EP1 -->|Issues| WRITE["skills:write"]:::skills
+    EP6 -->|Gaps| WRITE
+
+    classDef skills fill:#607D8B,stroke:#333,color:white
+```
+
+## When to Use
+
+- Setting up Claude Code skills in a new repository
+- Auditing an existing repo for skill gaps
+- Updating skills after the repo's tech stack or workflows changed
+- Onboarding to a new codebase
+
+## Mode: New Repo (no `.claude/skills/` exists)
+
+### Phase 1: Analyze Repository Structure
+
+Scan for technology markers:
+
+```bash
+ls -la Makefile pyproject.toml package.json Cargo.toml go.mod pom.xml 2>/dev/null
+```
+
+Check CI configuration:
+
+```bash
+ls .github/workflows/ .gitlab-ci.yml Jenkinsfile .circleci/ 2>/dev/null
+```
+
+Check deployment patterns:
+
+```bash
+ls -d charts/ helm/ k8s/ kubernetes/ deployments/ docker-compose* Dockerfile 2>/dev/null
+```
+
+Check test structure:
+
+```bash
+find . -type d -name "tests" -o -name "test" -o -name "__tests__" -o -name "e2e" 2>/dev/null | head -10
+```
+
+### Phase 2: Identify Skill Categories
+
+Based on findings, propose categories:
+
+| Marker | Suggested Skills |
+|--------|-----------------|
+| `.github/workflows/` | `ci:status`, `ci:monitoring`, `tdd:ci`, `rca:ci` |
+| `charts/` or `helm/` | `helm:debug` |
+| `Dockerfile` | `docker:build`, `docker:debug` |
+| `tests/e2e/` | `tdd:ci`, `rca:ci` |
+| `deployments/ansible/` | `deploy:ansible` |
+| Kubernetes manifests | `k8s:health`, `k8s:pods`, `k8s:logs` |
+| Kind/minikube configs | `tdd:kind`, `rca:kind` |
+| HyperShift/OpenShift | `tdd:hypershift`, `rca:hypershift` |
+
+### Phase 3: Generate Core Skills
+
+Every repo should have these (create with `skills:write`):
+
+| Skill | Purpose |
+|-------|---------|
+| `skills:write` | How to create skills |
+| `skills:validate` | How to validate skills |
+| `skills:scan` | This skill (self-referential) |
+| `tdd:ci` | CI-driven development loop (if CI exists) |
+| `rca:ci` | Root cause analysis from CI logs (if CI exists) |
+| `git:worktree` | Parallel development (if git repo) |
+
+### Phase 4: Generate settings.json
+
+Create `.claude/settings.json` with auto-approve patterns:
+- Read operations (kubectl get, logs, describe) → auto-approve
+- Sandbox write operations (kubectl apply on dev clusters) → auto-approve
+- Management/destructive operations → require approval
+
+## Mode: Existing Repo (`.claude/skills/` exists)
+
+### Phase 1: Validate Existing Skills
+
+Run `skills:validate` on every skill:
+
+```bash
+for f in .claude/skills/*/SKILL.md; do
+  dir=$(basename $(dirname "$f"))
+  name=$(grep '^name:' "$f" | sed 's/name: //' | tr -d ' ')
+  [ "$dir" = "$name" ] || echo "MISMATCH: $dir != $name"
+done
+```
+
+Check for issues:
+- Frontmatter name/directory mismatches
+- Old-style references (dashes instead of colons)
+- Missing Related Skills sections
+- Chained commands in sandbox skills (breaks auto-approve)
+
+### Phase 2: Gap Analysis
+
+Compare existing skills against the repo's actual tech stack:
+
+1. Run Phase 1 of the "New Repo" flow to detect technology markers
+2. Compare detected categories against existing skill categories
+3. List categories that exist in the repo but have no skills
+4. List skills that reference tools/patterns no longer in use
+
+### Phase 3: Content Quality Review
+
+For each existing skill, assess:
+
+| Check | Criteria |
+|-------|----------|
+| Actionability | Commands are copy-pasteable, not just documentation |
+| Length | 80-200 lines (300 max). Split if too long |
+| Freshness | Commands and paths still match current repo structure |
+| Cross-links | Related Skills use colon notation and link to real skills |
+| Auto-approve | Sandbox commands match settings.json patterns |
+| Mermaid diagram | Workflow/router skills have embedded diagram matching textual flow |
+| Dev docs consistency | Claims in `docs/developer/claude-code-skills.md` match actual skill behavior |
+
+### Phase 3b: Developer Docs Consistency
+
+If `docs/developer/claude-code-skills.md` exists, verify:
+
+1. **Skills listed in dev docs match actual skills** — no stale references
+2. **Workflow diagrams in dev docs match skill diagrams** — same nodes, same flow
+3. **Best practices in dev docs are enforced by skills** — worktree gate, checklist items
+4. **Sub-skill table is accurate** — inputs, outputs, invocations match reality
+
+### Phase 4: Connection Analysis
+
+For each skill, determine:
+- **Outgoing links**: Skills referenced in Related Skills section
+- **Incoming links**: Which other skills reference this one (search all files)
+- **Broken refs**: References to skills that don't exist
+- **Orphans**: Skills with no incoming references (only parent links)
+
+Key metrics:
+- Most connected skills (highest incoming refs) = hub skills
+- Orphaned skills = may need cross-linking or deletion
+- Broken refs = must fix before committing
+
+### Phase 5: Usefulness Assessment
+
+Rate each skill 1-5:
+
+| Rating | Criteria |
+|--------|----------|
+| 5 | Decision trees, copy-paste commands, troubleshooting, used daily |
+| 4 | Good reference with commands, covers edge cases |
+| 3 | Useful but needs more actionability or is too long |
+| 2 | Bare index or needs significant improvement |
+| 1 | Redundant or too vague to help |
+
+### Phase 6: Generate Report
+
+Save to `/tmp/kagenti/skills-scan/`:
+
+```bash
+mkdir -p /tmp/kagenti/skills-scan
+```
+
+Output a structured report:
+
+```markdown
+## Skill Scan Report
+
+### Inventory: X total (Y parents + Z leaves)
+- Rated 5: N skills
+- Rated 4: N skills
+- Rated 3 or below: N skills (list)
+
+### Validation Issues
+- Failing validation: [list with specific issues]
+- Broken references: [source → broken target]
+- Over 300 lines: [list with line counts]
+
+### Connection Analysis
+- Most connected (hub skills): [top 5 with incoming ref count]
+- Orphaned skills: [list with only parent refs]
+- Workflow paths: TDD escalation, RCA escalation, Deploy chain
+
+### Gap Analysis
+- Missing skills for detected tech: [list]
+- Stale skills referencing removed tech: [list]
+
+### Diagram Coverage
+- Skills with diagrams: [count]
+- Skills needing diagrams: [list]
+
+### Recommendations
+1. Create: [new skills needed]
+2. Update: [skills with issues]
+3. Delete: [obsolete skills]
+4. Merge: [overlapping skills]
+5. Cross-link: [orphaned skills that should connect to workflows]
+```
+
+## Phase 7: Update Skills README
+
+After completing the scan, update `.claude/skills/README.md`:
+
+1. Regenerate the **Complete Skill Tree** (ASCII listing of all categories and leaves)
+2. Update **Mermaid workflow diagrams** for root flows:
+   - TDD workflow (tdd → tdd:ci/tdd:hypershift/tdd:kind escalation)
+   - RCA workflow (rca → rca:ci/rca:hypershift/rca:kind escalation)
+   - CI workflow (ci → ci:status/ci:monitoring → rca:ci → tdd:ci)
+   - Skills meta workflow (skills:scan → skills:write → skills:validate → skills:retrospective)
+   - Deploy & debug workflow (kagenti:deploy → k8s:health → k8s:pods/logs)
+   - HyperShift lifecycle (setup → preflight → quotas → create → destroy)
+3. Update the **Auto-Approve Policy** table
+4. Verify all skills appear in the tree and diagrams
+5. Check that no orphaned skills exist (every leaf should be reachable from a root flow)
+
+The README is the main entry point for understanding the skills system.
+It should always reflect the current state after a scan.
+
+## Output (New Repo)
+
+```
+.claude/
+├── settings.json
+└── skills/
+    ├── README.md              # Generated by skills:scan
+    ├── skills/SKILL.md
+    ├── skills:write/SKILL.md
+    ├── skills:validate/SKILL.md
+    ├── skills:scan/SKILL.md
+    ├── tdd/SKILL.md
+    ├── tdd:ci/SKILL.md
+    ├── rca/SKILL.md
+    ├── rca:ci/SKILL.md
+    └── <detected>/SKILL.md
+```
+
+## Related Skills
+
+- `skills:write` - Create individual skills
+- `skills:validate` - Validate skill format
+- `skills:retrospective` - Review and improve skills after sessions
+- `tdd:ci` - Core TDD skill (always generated)
+- `rca:ci` - Core RCA skill (always generated)

--- a/.claude/skills/skills:validate/SKILL.md
+++ b/.claude/skills/skills:validate/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: skills:validate
+description: Validate skill files meet the standard format and naming conventions
+---
+
+# Validate Skill
+
+## When to Use
+
+- After creating or editing a skill
+- Before committing skill changes
+- When auditing all skills for consistency
+
+## Validation Checks
+
+### Required
+
+- [ ] **Frontmatter**: Has `name:` and `description:` fields
+- [ ] **Colon naming**: `name:` uses colon notation (e.g., `tdd:ci` not `tdd-ci`)
+- [ ] **Directory match**: Directory name matches frontmatter `name:` field
+- [ ] **Title**: Has `# Skill Name` as first heading
+- [ ] **When to Use**: Has "When to Use" or "Overview" section
+- [ ] **Related Skills**: Has "Related Skills" section at the end
+- [ ] **Mermaid diagram**: Workflow/router skills have an embedded mermaid diagram
+- [ ] **Diagram colors**: classDef colors match README color legend
+
+### Command Format (Required)
+
+- [ ] **Sandbox classification**: Skill is classified as sandbox or management (see below)
+- [ ] **Single commands**: Sandbox skills use one command per code block (no `&&` chaining)
+- [ ] **Auto-approve coverage**: All commands in sandbox skills match a pattern in `.claude/settings.json`
+- [ ] **No multiline bash**: Sandbox skills avoid heredocs, multiline pipes, or `for` loops in commands
+
+### Recommended
+
+- [ ] **TOC**: Table of Contents present if skill > 50 lines
+- [ ] **Placeholders**: All commands are copy-pasteable (no unexplained placeholders)
+- [ ] **Task tracking**: TDD/RCA skills have "Task Tracking" section
+- [ ] **Parent ref**: Parent category `SKILL.md` references this skill
+- [ ] **Imperative voice**: Uses "Run X" not "You should run X"
+- [ ] **Length**: Leaf skills are 80-200 lines (300 max)
+- [ ] **Diagram-text match**: Diagram nodes correspond to textual flow steps
+
+## Sandbox vs Management Classification
+
+Skills operate on either **sandbox** (safe) or **management** (requires approval) targets:
+
+| Type | Target | Auto-approve? | Command format |
+|------|--------|---------------|----------------|
+| **Sandbox** | Local Kind cluster, custom HyperShift hosted cluster | YES | Single commands, one per step |
+| **Management** | Management cluster, AWS resources, git push, destructive ops | NO | Can chain commands (user approves anyway) |
+
+### Sandbox skills (auto-approved)
+Commands target `localtest.me`, `KUBECONFIG=~/clusters/hcp/kagenti-hypershift-custom-*`, or Kind clusters.
+
+**IMPORTANT**: Run each command separately — not chained with `&&`. Chained or multiline commands break Claude Code's auto-approve pattern matching.
+
+```markdown
+## GOOD (each command runs separately, matches auto-approve patterns)
+
+Check pod status:
+```bash
+kubectl get pods -n kagenti-system
+```
+
+Check logs:
+```bash
+kubectl logs -n kagenti-system deployment/mlflow
+```
+
+## BAD (chained commands won't match auto-approve patterns)
+
+```bash
+kubectl get pods -n kagenti-system && kubectl logs -n kagenti-system deployment/mlflow
+```
+```
+
+### Management skills (require approval)
+Commands target management clusters, AWS APIs, or perform destructive operations. These can use any command format since the user must approve each one.
+
+## How to Validate
+
+### Single Skill
+
+```bash
+# Check frontmatter
+head -5 .claude/skills/<skill>/SKILL.md
+
+# Check name matches directory
+DIR_NAME=$(basename $(dirname .claude/skills/<skill>/SKILL.md))
+SKILL_NAME=$(grep '^name:' .claude/skills/<skill>/SKILL.md | sed 's/name: //')
+[ "$DIR_NAME" = "$SKILL_NAME" ] && echo "OK" || echo "MISMATCH: dir=$DIR_NAME name=$SKILL_NAME"
+```
+
+### All Skills
+
+```bash
+# Check all frontmatter name-vs-directory
+for f in .claude/skills/*/SKILL.md; do
+  dir=$(basename $(dirname "$f"))
+  name=$(grep '^name:' "$f" | sed 's/name: //' | tr -d ' ')
+  [ "$dir" = "$name" ] || echo "MISMATCH: $dir != $name"
+done
+```
+
+### Check Command Format (sandbox skills)
+
+```bash
+# Find chained commands in sandbox skills (potential auto-approve issues)
+grep -n ' && ' .claude/skills/k8s:*/SKILL.md .claude/skills/kagenti:*/SKILL.md .claude/skills/kind:*/SKILL.md .claude/skills/local:*/SKILL.md .claude/skills/tdd:*/SKILL.md .claude/skills/rca:*/SKILL.md
+```
+
+### Check Mermaid Diagram Presence
+
+```bash
+for f in .claude/skills/*/SKILL.md; do
+  dir=$(basename $(dirname "$f"))
+  case "$dir" in git|k8s|auth|openshift|local|kind|helm|meta|genai|repo|testing) continue ;; esac
+  if ! grep -q '```mermaid' "$f"; then
+    echo "MISSING DIAGRAM: $dir"
+  fi
+done
+```
+
+### Verify settings.json Coverage
+
+For each command in a sandbox skill, verify it matches a pattern in `.claude/settings.json`:
+
+| Command prefix | settings.json pattern |
+|----------------|----------------------|
+| `kubectl get` | `Bash(kubectl get:*)` |
+| `kubectl describe` | `Bash(kubectl describe:*)` |
+| `kubectl logs` | `Bash(kubectl logs:*)` |
+| `helm list` | `Bash(helm list:*)` |
+| `KUBECONFIG=~/clusters/hcp/... kubectl` | `Bash(KUBECONFIG=*/clusters/hcp/kagenti-hypershift-custom-*/auth/kubeconfig kubectl:*)` |
+| `uv run pytest` | `Bash(uv run pytest:*)` |
+
+If a command is NOT covered, add the pattern to `.claude/settings.json` in the `allow` array.
+
+## Task Tracking
+
+When validating multiple skills:
+
+```
+TaskCreate: "kagenti | skills | <category> | Verify | Validate <skill-name>"
+```
+
+## Related Skills
+
+- `skills:write` - Create new skills following the standard
+- `skills:retrospective` - Review session to identify skill improvements

--- a/.claude/skills/skills:write/SKILL.md
+++ b/.claude/skills/skills:write/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: skills:write
+description: Create or edit skills with proper structure, task tracking, and naming conventions
+---
+
+# Write / Edit Skill
+
+Create new skills or edit existing ones. Both follow the same checklist and conventions.
+
+## Worktree Gate
+
+**All skill work MUST happen in a worktree.** Before proceeding, verify you are in a worktree:
+
+```bash
+git worktree list
+```
+
+If not in a worktree, create one first:
+
+```bash
+git fetch upstream main
+```
+
+```bash
+git worktree add .worktrees/skills-<topic> -b docs/skills-<topic> upstream/main
+```
+
+## Table of Contents
+
+- [Skill Structure](#skill-structure)
+- [Frontmatter](#frontmatter)
+- [Content Guidelines](#content-guidelines)
+- [Task Tracking Standard](#task-tracking-standard)
+- [Checklist](#checklist)
+- [Template](#template)
+
+## New vs Edit
+
+| Action | Steps |
+|--------|-------|
+| **New skill** | Create directory + SKILL.md from template, fill in content, validate |
+| **Edit skill** | Read existing file first, apply changes, re-validate, ensure diagram still matches text |
+
+For edits: always read the skill FIRST, then edit. Never overwrite without reading.
+
+## Skill Structure
+
+```
+.claude/skills/<category>:<skill-name>/
+└── SKILL.md
+```
+
+**IMPORTANT**: Use colon notation in directory names (e.g., `auth:my-skill/`). Required for Claude Code skill discovery.
+
+Categories: `auth`, `ci`, `genai`, `git`, `hypershift`, `istio`, `k8s`, `kagenti`, `kind`, `local`, `openshift`, `rca`, `skills`, `tdd`, `testing`
+
+## Frontmatter
+
+```yaml
+---
+name: category:skill-name
+description: One-line description (what it does, not how)
+---
+```
+
+Use colon notation in `name:` field. Directory name must match.
+
+## Content Guidelines
+
+1. **Title**: `# Skill Name`
+2. **TOC**: Include for skills over 50 lines
+3. **Length**: Target 80-200 lines (300 max). Split longer skills.
+4. **Sections**:
+   - When to Use
+   - Steps/Workflow
+   - Workflow Diagram (required for workflow/router skills)
+   - Task Tracking (required for workflow skills)
+   - Troubleshooting
+   - Related Skills
+5. **Style**:
+   - Imperative voice ("Run X", not "You should run X")
+   - Real, copy-pasteable commands
+   - Include expected output where helpful
+
+## Command Format and Auto-Approve
+
+Skills must classify as **sandbox** or **management** to determine command format:
+
+| Type | Target | Auto-approve? |
+|------|--------|---------------|
+| **Sandbox** | Kind cluster, custom HyperShift hosted cluster | YES |
+| **Management** | Management cluster, AWS resources, git push, destructive ops | NO |
+
+### Sandbox skills: One command per code block
+
+Claude Code auto-approves commands by matching the first token against `.claude/settings.json` patterns. Chained commands (`&&`), multiline scripts, heredocs, and `for` loops break pattern matching.
+
+**IMPORTANT**: Write each command as a separate code block:
+
+```markdown
+Check pod status:
+```bash
+kubectl get pods -n kagenti-system
+```
+
+Check logs:
+```bash
+kubectl logs -n kagenti-system deployment/mlflow
+```
+```
+
+Do NOT chain: `kubectl get pods && kubectl logs ...`
+
+For HyperShift, prefix each command individually:
+
+```markdown
+```bash
+KUBECONFIG=~/clusters/hcp/kagenti-hypershift-custom-$CLUSTER/auth/kubeconfig kubectl get pods -n kagenti-system
+```
+```
+
+### Management skills: Any format
+
+Commands targeting management clusters or AWS need user approval anyway, so multiline/chained format is acceptable.
+
+### Temporary Files
+
+Skills that download logs, artifacts, or save analysis output should use `/tmp/kagenti/<skill-category>/` as the working directory:
+
+```bash
+mkdir -p /tmp/kagenti/rca
+```
+
+This path is auto-approved for read/write in `.claude/settings.json`.
+
+### Update settings.json
+
+After writing a skill, verify all sandbox commands are covered by `.claude/settings.json` patterns. If a new command prefix is used, add it:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(new-command:*)"
+    ]
+  }
+}
+```
+
+See `skills:validate` for the full pattern reference table.
+
+## Workflow Diagrams
+
+Workflow skills (skills with phases, decision trees, or routing logic) MUST include:
+
+1. **Embedded mermaid diagram** in the SKILL.md
+2. **Companion `.mmd` template file** in the skill directory (for debug mode, TDD skills only)
+3. Diagram MUST match textual flow exactly
+4. Use README color scheme:
+
+| Category | classDef |
+|----------|----------|
+| TDD | `classDef tdd fill:#4CAF50,stroke:#333,color:white` |
+| RCA | `classDef rca fill:#FF5722,stroke:#333,color:white` |
+| CI | `classDef ci fill:#2196F3,stroke:#333,color:white` |
+| Test | `classDef test fill:#9C27B0,stroke:#333,color:white` |
+| Git | `classDef git fill:#FF9800,stroke:#333,color:white` |
+| K8s | `classDef k8s fill:#00BCD4,stroke:#333,color:white` |
+| Deploy | `classDef deploy fill:#795548,stroke:#333,color:white` |
+| Skills | `classDef skills fill:#607D8B,stroke:#333,color:white` |
+| GitHub | `classDef github fill:#E91E63,stroke:#333,color:white` |
+| HyperShift | `classDef hypershift fill:#3F51B5,stroke:#333,color:white` |
+| Playwright | `classDef pw fill:#8BC34A,stroke:#333,color:white` |
+
+**Exempt** from diagram requirement: pure index parents that only list sub-skills with no routing logic (e.g., `git/`, `k8s/`, `auth/`)
+
+## Task Tracking Standard
+
+Every workflow skill (tdd, rca, ci, etc.) MUST include a Task Tracking section. This is the canonical reference for how Claude Code task lists work across all skills.
+
+### Task Naming Convention
+
+```
+<worktree> | <PR> | <plan-doc> | <topic> | <phase> | <task description>
+```
+
+- **worktree**: git worktree name (e.g., `mlflow-ci`) or `kagenti` for main repo
+- **PR**: PR reference (e.g., `PR#569`) or `none`
+- **plan-doc**: plan filename (e.g., `calm-toast.md`) or `ad-hoc` if no plan
+- **topic**: area of work (e.g., `Kind CI`, `MLflow init`, `CodeQL`)
+- **phase**: from planning doc section/step, or blank if ad-hoc
+- **task**: brief description
+
+Examples:
+- `mlflow-ci | PR#569 | calm-toast.md | MLflow init | Phase 2: Fix | Use parameterized SQL`
+- `mlflow-ci | PR#569 | ad-hoc | Kind CI | | Bind Ollama to 0.0.0.0`
+- `kagenti | none | calm-toast.md | skills | Step 1 | Create ci:status skill`
+
+### Task Lifecycle
+
+```
+1. On skill invocation:
+   - TaskList → check existing tasks for this worktree/PR
+   - Update completed items
+   - Create new items for discovered work
+
+2. Task metadata:
+   - plan: path to plan doc or "ad-hoc" if none
+   - runner: main-session | subagent | background
+
+3. Dependencies:
+   - Use addBlockedBy for sequential tasks
+   - Parallel tasks have no blockers
+
+4. Status reporting - always show plan doc in task name:
+   | # | Status | Task (includes plan doc) |
+   |---|--------|-------------------------|
+   | #26 | in_progress | kagenti \| none \| calm-toast.md \| skills \| Create \| ci:status |
+   | #32 | completed | mlflow-ci \| PR#569 \| ad-hoc \| Kind CI \| Fix \| Ollama bind |
+```
+
+### Plan Doc Reference
+
+Every task should reference its parent planning document:
+- Tasks from a plan: `metadata.plan = "<plan-file-path>"`
+- Ad-hoc tasks: `metadata.plan = "ad-hoc"`
+- Tasks without a plan doc indicate work that needs retroactive documentation
+
+## Checklist
+
+Before committing a new skill:
+
+- [ ] Frontmatter has `name` and `description`
+- [ ] Directory uses colon notation
+- [ ] Name in frontmatter matches directory name
+- [ ] TOC included if over 50 lines
+- [ ] Commands are copy-pasteable
+- [ ] Task Tracking section present (for workflow skills)
+- [ ] Troubleshooting section exists
+- [ ] Related Skills section exists
+- [ ] Mermaid diagram present (for workflow/router skills)
+- [ ] Diagram matches textual workflow exactly
+- [ ] Diagram uses classDef colors from README color legend
+- [ ] Parent category SKILL.md updated with reference
+
+## Template
+
+```markdown
+---
+name: category:skill-name
+description: Brief description of what this skill does
+---
+
+# Skill Name
+
+## When to Use
+
+- Condition 1
+- Condition 2
+
+## Workflow
+
+1. Step one
+2. Step two
+
+## Workflow Diagram
+
+```mermaid
+flowchart TD
+    START(["/category:skill"]) --> STEP1["Step 1"]:::category
+    STEP1 --> STEP2["Step 2"]:::category
+
+    classDef category fill:#COLOR,stroke:#333,color:white
+```
+
+## Task Tracking
+
+On invocation:
+1. TaskList - check existing tasks
+2. TaskCreate with naming: `<worktree> | <PR> | <topic> | <phase> | <task>`
+3. TaskUpdate as work progresses
+
+## Troubleshooting
+
+### Problem: Description
+**Symptom**: What you see
+**Fix**: How to resolve
+
+## Related Skills
+
+- `category:related-skill`
+```
+
+## Related Skills
+
+- `skills:validate` - Check skill format compliance
+- `skills:retrospective` - Identify skill gaps and improvements
+- `meta:write-docs` - Documentation formatting guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,28 @@ All commits must include a `Signed-off-by` trailer:
 ```sh
 git commit -s -m "feat: add feature"
 ```
+
+## Orchestration
+
+This repo includes orchestrate skills for enhancing related repos.
+Run from within this repo after cloning a target into `.repos/<target>/`:
+
+```bash
+git clone git@github.com:org/repo.git .repos/repo-name
+# then invoke via Claude Code:
+# /orchestrate .repos/repo-name
+```
+
+| Skill | Description |
+|-------|-------------|
+| `orchestrate` | Router — start here with `/orchestrate <repo-path>` |
+| `orchestrate:scan` | Assess repo structure, tech stack, and gaps |
+| `orchestrate:plan` | Create a phased enhancement plan |
+| `orchestrate:precommit` | Add pre-commit hooks and linting baseline |
+| `orchestrate:tests` | Add test infrastructure and initial coverage |
+| `orchestrate:ci` | Add CI workflows (lint, test, build, security, dependabot) |
+| `orchestrate:security` | Add security governance (CODEOWNERS, SECURITY.md) |
+| `orchestrate:replicate` | Bootstrap orchestrate skills into the target |
+| `skills:scan` | Discover skills in any repo |
+| `skills:write` | Author new skills |
+| `skills:validate` | Validate skill structure and frontmatter |


### PR DESCRIPTION
## Summary

Phase 6 (final) of repo orchestration. Copies 11 orchestrate/skills skills
into `.claude/skills/`, making this repo capable of orchestrating related
repos without any dependency on the originating hub.

## Skills Added

| Skill | Purpose |
|-------|---------|
| `orchestrate` | Router — entry point for `/orchestrate <repo-path>` |
| `orchestrate:scan` | Assess repo structure, tech stack, gaps |
| `orchestrate:plan` | Create phased enhancement plan |
| `orchestrate:precommit` | Add pre-commit hooks and lint baseline |
| `orchestrate:tests` | Add test infrastructure and initial coverage |
| `orchestrate:ci` | Add CI workflows (lint, test, build, security, dependabot, scorecard) |
| `orchestrate:security` | Add security governance (CODEOWNERS, SECURITY.md, .gitignore) |
| `orchestrate:replicate` | Self-replicating — bootstrap skills into another target |
| `skills:scan` | Discover skills in any repo |
| `skills:write` | Author new skills following conventions |
| `skills:validate` | Validate skill structure and frontmatter |

## Adaptations from Source

- `orchestrate:ci`: removed hub-specific reference ("kagenti/kagenti gold standard" → generic); updated SHA lookup guidance to be repo-agnostic

## Validation

- ✅ All 11 skills pass `name:` / directory frontmatter check
- ✅ No source-specific paths or org references remain
- ✅ All Related Skills sections reference skills within the copied set

## Also Includes

**`CLAUDE.md`** — project overview with:
- Repository structure and key commands
- Code style and DCO guidance
- Orchestration section documenting all available skills and usage pattern

## The Fractal

After this PR merges, `plugins-adapter` can orchestrate any related repo:

```bash
git clone git@github.com:kagenti/some-other-repo.git .repos/some-other-repo
# In Claude Code (from plugins-adapter root):
# /orchestrate .repos/some-other-repo
```

Each downstream repo that goes through Phase 6 becomes independently capable of the same.