### PR TITLE
fix: :wrench: Add filter priority

### DIFF
--- a/filter.yaml
+++ b/filter.yaml
@@ -2,8 +2,11 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: plugins-adapter-filter
+  # Note this uses the root namespace. This can be moved depending on
+  # namespace used for the MCP gateway router
   namespace: istio-system
 spec:
+  priority: 10 # After MCP gateway router if available
   workloadSelector:
     labels:
       istio: ingressgateway


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

As detailed in [this comment](https://github.com/kagenti/plugins-adapter/issues/85#issuecomment-4164181876), v0.5.1 changes to MCP gateway for the operator-based deployment changed the namespace for MCP gateway filter deployment. Because the plugin adapter ext-proc filter here was still in the root namespace, the filter ordering unintentionally changed. To keep the default ordering to post MCP gateway router, a priority is introduced here, but users are free to change the namespace deployed for this filter as well to match the MCP gateway filter namespace if the MCP gateway is available.

## Related issue(s)

Fixes #85 
