### PR TITLE
ci: Add org-wide project automation workflow

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -21,4 +21,3 @@ jobs:
     # Pinned to @main intentionally: org-internal workflows propagate updates automatically.
     uses: kagenti/.github/.github/workflows/add-to-project.yml@main
     secrets: inherit
-

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,24 @@
+name: Kagenti Project Automation
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  add:
+    name: Add item to Kagenti Project
+
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+
+    # Pinned to @main intentionally: org-internal workflows propagate updates automatically.
+    uses: kagenti/.github/.github/workflows/add-to-project.yml@main
+    secrets: inherit
+


### PR DESCRIPTION
## Summary

- Add thin caller for the org-wide project automation workflow from kagenti/.github
- Auto-adds new issues and PRs to the kagenti prioritization project

Closes #111

Matches kagenti/kagenti#1253.